### PR TITLE
Add confirmation dialog for timer session cancellation

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -296,6 +296,8 @@ function showTimerUI() {
     document.getElementById('timer-confirm-btn').classList.add('hidden');
     document.getElementById('timer-cancel-btn').classList.add('hidden');
     document.getElementById('timer-discard-btn').classList.remove('hidden');
+    document.getElementById('timer-discard-confirm-btn').classList.add('hidden');
+    document.getElementById('timer-discard-back-btn').classList.add('hidden');
 
     const breastTimesEl = document.getElementById('timer-breast-times');
 
@@ -450,7 +452,31 @@ function initTimer() {
     });
 
     document.getElementById('timer-discard-btn').addEventListener('click', () => {
+        document.getElementById('timer-end-btn').classList.add('hidden');
+        document.getElementById('timer-switch-btn').classList.add('hidden');
+        document.getElementById('timer-pause-btn').classList.add('hidden');
+        document.getElementById('timer-discard-btn').classList.add('hidden');
+        document.getElementById('timer-discard-confirm-btn').classList.remove('hidden');
+        document.getElementById('timer-discard-back-btn').classList.remove('hidden');
+    });
+
+    document.getElementById('timer-discard-confirm-btn').addEventListener('click', () => {
         cancelTimer();
+    });
+
+    document.getElementById('timer-discard-back-btn').addEventListener('click', () => {
+        document.getElementById('timer-end-btn').classList.remove('hidden');
+        const state = getTimerState();
+        if (state) {
+            const currentSide = state.segments[state.segments.length - 1].side;
+            if (!state.paused && (currentSide === 'breast_left' || currentSide === 'breast_right')) {
+                document.getElementById('timer-switch-btn').classList.remove('hidden');
+            }
+            document.getElementById('timer-pause-btn').classList.remove('hidden');
+        }
+        document.getElementById('timer-discard-confirm-btn').classList.add('hidden');
+        document.getElementById('timer-discard-back-btn').classList.add('hidden');
+        document.getElementById('timer-discard-btn').classList.remove('hidden');
     });
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -31,6 +31,8 @@
                 <button id="timer-confirm-btn" class="btn btn-danger btn-lg hidden">Confirm End</button>
                 <button id="timer-cancel-btn" class="btn btn-secondary hidden">Cancel</button>
                 <button id="timer-discard-btn" class="btn btn-secondary hidden">Cancel Session</button>
+                <button id="timer-discard-confirm-btn" class="btn btn-danger hidden">Confirm Cancel</button>
+                <button id="timer-discard-back-btn" class="btn btn-secondary hidden">Keep Session</button>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
This PR adds a confirmation step when users attempt to cancel a timer session, preventing accidental loss of session data.

## Key Changes
- Added two new buttons to the timer UI: "Confirm Cancel" and "Keep Session"
- Modified the discard button behavior to show a confirmation dialog instead of immediately canceling
- Implemented a back button that restores the previous timer UI state when the user chooses not to cancel
- Updated button visibility logic to properly show/hide timer controls during the confirmation flow

## Implementation Details
- When the "Cancel Session" button is clicked, the active timer controls are hidden and confirmation buttons are displayed
- The "Confirm Cancel" button triggers the actual `cancelTimer()` function
- The "Keep Session" button restores the previous UI state, intelligently re-showing the appropriate timer controls based on the current timer state (pause button always shown, switch button only shown if timer is running on a breast side)
- All button state management is handled through CSS class toggling (hidden/visible)

https://claude.ai/code/session_01FJTTD1RhVBcUkpuUwu7YaR