### PR TITLE
Fix summary cards to show counts for the displayed day, not always today

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -184,6 +184,24 @@ def _feeding_session_count(db: Session, start: datetime) -> int:
     return db.execute(stmt).scalar() or 0
 
 
+def _count_range(db: Session, model, timestamp_col, start: datetime, end: datetime) -> int:
+    stmt = (
+        select(func.count())
+        .select_from(model)
+        .where(timestamp_col >= start, timestamp_col < end)
+    )
+    return db.execute(stmt).scalar() or 0
+
+
+def _feeding_session_count_range(db: Session, start: datetime, end: datetime) -> int:
+    session_key = func.coalesce(Feeding.session_id, cast(Feeding.id, String))
+    stmt = select(func.count(func.distinct(session_key))).where(
+        Feeding.timestamp >= start,
+        Feeding.timestamp < end,
+    )
+    return db.execute(stmt).scalar() or 0
+
+
 def feeding_stats(db: Session) -> dict[str, int]:
     local_tz = _get_local_tz()
     now = datetime.now(local_tz)
@@ -494,13 +512,19 @@ def get_activities(
 # --- Dashboard ---
 
 
-def get_dashboard(db: Session) -> dict:
+def get_dashboard(db: Session, date_str: str | None = None) -> dict:
     now = datetime.now(UTC)
 
     # Stats
     d_stats = diaper_stats(db)
     f_stats = feeding_stats(db)
     med_today = _period_count(db, Medication, Medication.timestamp, "today")
+
+    if date_str:
+        start, end = _day_bounds(date_str)
+        d_stats["today"] = _count_range(db, DiaperChange, DiaperChange.timestamp, start, end)
+        f_stats["today"] = _feeding_session_count_range(db, start, end)
+        med_today = _count_range(db, Medication, Medication.timestamp, start, end)
 
     # Last entries
     last_diaper = db.execute(

--- a/src/puffin/routers/dashboard.py
+++ b/src/puffin/routers/dashboard.py
@@ -17,8 +17,11 @@ _PDF_MAX_CELL_LENGTH = 40  # max characters per cell before truncation
 
 
 @router.get("/dashboard", response_model=DashboardSummary)
-def get_dashboard(db: Session = Depends(get_db)):
-    return crud.get_dashboard(db)
+def get_dashboard(
+    date: str | None = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    db: Session = Depends(get_db),
+):
+    return crud.get_dashboard(db, date_str=date)
 
 
 @router.get("/export")

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1209,20 +1209,20 @@ function updateCalendarUI() {
 function prevDay() {
     currentDate.setDate(currentDate.getDate() - 1);
     updateCalendarUI();
-    loadDayActivities();
+    loadDashboard();
 }
 
 function nextDay() {
     if (isSameDay(currentDate, new Date())) return;
     currentDate.setDate(currentDate.getDate() + 1);
     updateCalendarUI();
-    loadDayActivities();
+    loadDashboard();
 }
 
 function goToToday() {
     currentDate = new Date();
     updateCalendarUI();
-    loadDayActivities();
+    loadDashboard();
 }
 
 function initCalendar() {
@@ -1242,7 +1242,7 @@ function initCalendar() {
         const [y, m, d] = picker.value.split('-').map(Number);
         currentDate = new Date(y, m - 1, d);
         updateCalendarUI();
-        loadDayActivities();
+        loadDashboard();
     });
 
     updateCalendarUI();
@@ -1296,7 +1296,14 @@ function timeAgo(isoStr) {
 
 async function loadDashboard() {
     try {
-        const data = await api.get('/api/dashboard');
+        const dateStr = toDateString(currentDate);
+        const data = await api.get(`/api/dashboard?date=${dateStr}`);
+
+        // Summary card titles reflect the displayed day
+        const isToday = isSameDay(currentDate, new Date());
+        document.getElementById('diaper-title').textContent = isToday ? 'Diapers Today' : 'Diapers';
+        document.getElementById('feeding-title').textContent = isToday ? 'Feedings Today' : 'Feedings';
+        document.getElementById('med-title').textContent = isToday ? 'Meds Today' : 'Meds';
 
         // Summary cards
         document.getElementById('diaper-count').textContent = data.diaper_stats.today;

--- a/templates/index.html
+++ b/templates/index.html
@@ -46,17 +46,17 @@
         <!-- Dashboard Summary Cards -->
         <section class="summary-cards" id="summary-cards">
             <div class="card card-diaper">
-                <h3>Diapers Today</h3>
+                <h3 id="diaper-title">Diapers Today</h3>
                 <div class="card-value" id="diaper-count">-</div>
                 <div class="card-detail" id="last-diaper">—</div>
             </div>
             <div class="card card-feeding">
-                <h3>Feedings Today</h3>
+                <h3 id="feeding-title">Feedings Today</h3>
                 <div class="card-value" id="feeding-count">-</div>
                 <div class="card-detail" id="last-feeding">—</div>
             </div>
             <div class="card card-health">
-                <h3>Meds Today</h3>
+                <h3 id="med-title">Meds Today</h3>
                 <div class="card-value" id="med-count">-</div>
                 <div class="card-detail" id="last-temp">—</div>
             </div>


### PR DESCRIPTION
The /api/dashboard endpoint now accepts an optional `date` query param
(YYYY-MM-DD). When provided, diaper/feeding/medication counts are
computed for that specific day using the existing _day_bounds helper
rather than the rolling "today" window.

The frontend passes currentDate to every dashboard fetch and updates
card titles ("Diapers Today" vs "Diapers") to reflect which day is
displayed. Date navigation now also refreshes the summary cards.

Closes #24

https://claude.ai/code/session_01Qi2awPoKiAAMj3hZNwmaX6