### PR TITLE
Split medication dosage into dosage_quantity and dosage_unit fields

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -223,13 +223,15 @@ def create_medication(
     db: Session,
     timestamp: datetime | None,
     medication_name: str,
-    dosage: str,
+    dosage_quantity: float,
+    dosage_unit: str,
     notes: str | None,
 ) -> Medication:
     obj = Medication(
         timestamp=timestamp or datetime.now(UTC),
         medication_name=medication_name,
-        dosage=dosage,
+        dosage_quantity=dosage_quantity,
+        dosage_unit=dosage_unit,
         notes=notes,
     )
     db.add(obj)
@@ -484,7 +486,7 @@ def get_activities(
                 "id": m.id,
                 "emoji": "\U0001f48a",
                 "label": m.medication_name,
-                "detail": m.dosage,
+                "detail": f"{m.dosage_quantity:.2f} {m.dosage_unit}",
                 "summary": f"Med: {m.medication_name}",
                 "notes": m.notes,
             }

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -1,8 +1,57 @@
 import os
+import re
 from pathlib import Path
 
 from sqlalchemy import create_engine, inspect, text
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
+
+_DOSAGE_UNIT_MAP = {
+    "ml": "mL",
+    "mL": "mL",
+    "tsp": "tsp(s)",
+    "tsps": "tsp(s)",
+    "teaspoon": "tsp(s)",
+    "teaspoons": "tsp(s)",
+    "tbsp": "tbsp(s)",
+    "tbsps": "tbsp(s)",
+    "tablespoon": "tbsp(s)",
+    "tablespoons": "tbsp(s)",
+    "drop": "drop(s)",
+    "drops": "drop(s)",
+    "spray": "spray(s)",
+    "sprays": "spray(s)",
+    "tablet": "tablet(s)",
+    "tablets": "tablet(s)",
+    "tab": "tablet(s)",
+    "unit": "unit(s)",
+    "units": "unit(s)",
+}
+
+
+def _parse_dosage(dosage: str) -> tuple[float, str]:
+    """Attempt to parse a free-text dosage string into (quantity, unit).
+
+    Used during the data migration from the old single dosage field.
+    Returns (0.0, 'unit(s)') when the string cannot be parsed.
+    """
+    if not dosage:
+        return 0.0, "unit(s)"
+    dosage = dosage.strip()
+    m = re.match(r"^(\d+(?:\.\d{1,2})?)\s*([a-zA-Z]+)", dosage)
+    if m:
+        try:
+            qty = round(float(m.group(1)), 2)
+            unit = _DOSAGE_UNIT_MAP.get(m.group(2), _DOSAGE_UNIT_MAP.get(m.group(2).lower(), "unit(s)"))
+            return qty, unit
+        except ValueError:
+            pass
+    m = re.match(r"^(\d+(?:\.\d{1,2})?)$", dosage)
+    if m:
+        try:
+            return round(float(m.group(1)), 2), "unit(s)"
+        except ValueError:
+            pass
+    return 0.0, "unit(s)"
 
 DB_PATH = os.environ.get(
     "PUFFIN_DB_PATH",
@@ -42,6 +91,30 @@ def _run_migrations(bind=None) -> None:
         existing_cols = {c["name"] for c in inspect(conn).get_columns("feedings")}
         if "session_id" not in existing_cols:
             conn.execute(text("ALTER TABLE feedings ADD COLUMN session_id TEXT"))
+            conn.commit()
+
+        insp = inspect(conn)
+        if not insp.has_table("medications"):
+            return
+        med_cols = {c["name"] for c in insp.get_columns("medications")}
+        if "dosage_quantity" not in med_cols:
+            conn.execute(
+                text("ALTER TABLE medications ADD COLUMN dosage_quantity REAL NOT NULL DEFAULT 0.0")
+            )
+            conn.execute(
+                text("ALTER TABLE medications ADD COLUMN dosage_unit TEXT NOT NULL DEFAULT 'unit(s)'")
+            )
+            conn.commit()
+            # Attempt to migrate existing free-text dosage values
+            rows = conn.execute(text("SELECT id, dosage FROM medications")).fetchall()
+            for row_id, dosage_text in rows:
+                qty, unit = _parse_dosage(dosage_text or "")
+                conn.execute(
+                    text(
+                        "UPDATE medications SET dosage_quantity = :qty, dosage_unit = :unit WHERE id = :id"
+                    ),
+                    {"qty": qty, "unit": unit, "id": row_id},
+                )
             conn.commit()
 
 

--- a/src/puffin/models.py
+++ b/src/puffin/models.py
@@ -65,7 +65,8 @@ class Medication(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     timestamp: Mapped[datetime] = mapped_column(_TZ_DATETIME, nullable=False, default=_utcnow)
     medication_name: Mapped[str] = mapped_column(String, nullable=False)
-    dosage: Mapped[str] = mapped_column(String, nullable=False)
+    dosage_quantity: Mapped[float] = mapped_column(Float, nullable=False)
+    dosage_unit: Mapped[str] = mapped_column(String, nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(_TZ_DATETIME, default=_utcnow)
 

--- a/src/puffin/routers/dashboard.py
+++ b/src/puffin/routers/dashboard.py
@@ -113,7 +113,7 @@ def export_data(
             [
                 _fmt_ts(m.timestamp),
                 m.medication_name,
-                m.dosage,
+                f"{m.dosage_quantity:.2f} {m.dosage_unit}",
                 m.notes or "",
             ]
             for m in medications
@@ -165,9 +165,9 @@ def export_data(
 
     writer.writerow([])
     writer.writerow(["--- Medications ---"])
-    writer.writerow(["id", "timestamp", "medication_name", "dosage", "notes", "created_at"])
+    writer.writerow(["id", "timestamp", "medication_name", "dosage_quantity", "dosage_unit", "notes", "created_at"])
     for m in medications:
-        writer.writerow([m.id, m.timestamp, m.medication_name, m.dosage, m.notes, m.created_at])
+        writer.writerow([m.id, m.timestamp, m.medication_name, m.dosage_quantity, m.dosage_unit, m.notes, m.created_at])
 
     writer.writerow([])
     writer.writerow(["--- Temperature Readings ---"])

--- a/src/puffin/routers/health.py
+++ b/src/puffin/routers/health.py
@@ -13,6 +13,7 @@ from puffin.schemas import (
     TemperatureCreate,
     TemperatureResponse,
     TemperatureUpdate,
+    DosageUnit,
 )
 
 router = APIRouter(tags=["health"])
@@ -27,7 +28,8 @@ def create_medication(data: MedicationCreate, db: Session = Depends(get_db)):
         db,
         timestamp=data.timestamp,
         medication_name=data.medication_name,
-        dosage=data.dosage,
+        dosage_quantity=data.dosage_quantity,
+        dosage_unit=data.dosage_unit.value,
         notes=data.notes,
     )
 
@@ -65,8 +67,10 @@ def update_medication(medication_id: int, data: MedicationUpdate, db: Session = 
         updates["timestamp"] = data.timestamp
     if data.medication_name is not None:
         updates["medication_name"] = data.medication_name
-    if data.dosage is not None:
-        updates["dosage"] = data.dosage
+    if data.dosage_quantity is not None:
+        updates["dosage_quantity"] = data.dosage_quantity
+    if data.dosage_unit is not None:
+        updates["dosage_unit"] = data.dosage_unit.value
     if data.notes is not None:
         updates["notes"] = data.notes
     obj = crud.update_medication(db, medication_id, **updates)

--- a/src/puffin/schemas.py
+++ b/src/puffin/schemas.py
@@ -1,7 +1,8 @@
+from decimal import Decimal
 from datetime import datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, field_validator
 
 # --- Enums ---
 
@@ -24,6 +25,16 @@ class TemperatureLocation(StrEnum):
     oral = "oral"
     axillary = "axillary"
     temporal = "temporal"
+
+
+class DosageUnit(StrEnum):
+    mL = "mL"
+    tsp = "tsp(s)"
+    tbsp = "tbsp(s)"
+    drop = "drop(s)"
+    spray = "spray(s)"
+    tablet = "tablet(s)"
+    unit = "unit(s)"
 
 
 # --- Diaper Schemas ---
@@ -87,18 +98,40 @@ class FeedingResponse(BaseModel):
 # --- Medication Schemas ---
 
 
+def _validate_dosage_quantity(v: float) -> float:
+    if Decimal(str(v)).as_tuple().exponent < -2:
+        raise ValueError("Quantity must have at most 2 decimal places")
+    if v <= 0:
+        raise ValueError("Quantity must be greater than zero")
+    return v
+
+
 class MedicationCreate(BaseModel):
     timestamp: datetime | None = None
     medication_name: str
-    dosage: str
+    dosage_quantity: float
+    dosage_unit: DosageUnit
     notes: str | None = None
+
+    @field_validator("dosage_quantity")
+    @classmethod
+    def check_dosage_quantity(cls, v: float) -> float:
+        return _validate_dosage_quantity(v)
 
 
 class MedicationUpdate(BaseModel):
     timestamp: datetime | None = None
     medication_name: str | None = None
-    dosage: str | None = None
+    dosage_quantity: float | None = None
+    dosage_unit: DosageUnit | None = None
     notes: str | None = None
+
+    @field_validator("dosage_quantity")
+    @classmethod
+    def check_dosage_quantity(cls, v: float | None) -> float | None:
+        if v is None:
+            return v
+        return _validate_dosage_quantity(v)
 
 
 class MedicationResponse(BaseModel):
@@ -107,7 +140,8 @@ class MedicationResponse(BaseModel):
     id: int
     timestamp: datetime
     medication_name: str
-    dosage: str
+    dosage_quantity: float
+    dosage_unit: str
     notes: str | None
     created_at: datetime
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -608,7 +608,7 @@ function initFeedingForm() {
 }
 
 /* ===== Auto-fill Suggestions ===== */
-let medDosageMap = {}; // medication_name -> most recent dosage
+let medDosageMap = {}; // medication_name -> { dosage_quantity, dosage_unit }
 
 async function loadMedSuggestions() {
     try {
@@ -621,7 +621,7 @@ async function loadMedSuggestions() {
             const name = m.medication_name;
             if (!seen.has(name)) {
                 seen.add(name);
-                medDosageMap[name] = m.dosage;
+                medDosageMap[name] = { dosage_quantity: m.dosage_quantity, dosage_unit: m.dosage_unit };
             }
         }
         datalist.innerHTML = [...seen].map(n => `<option value="${escapeAttr(n)}">`).join('');
@@ -632,18 +632,21 @@ async function loadMedSuggestions() {
 
 function initMedAutoFill() {
     const nameInput = document.getElementById('med-name');
-    const dosageInput = document.getElementById('med-dosage');
+    const qtyInput = document.getElementById('med-dosage-qty');
+    const unitSelect = document.getElementById('med-dosage-unit');
     nameInput.addEventListener('input', () => {
         const match = medDosageMap[nameInput.value];
-        if (match && !dosageInput.value) {
-            dosageInput.value = match;
+        if (match && !qtyInput.value) {
+            qtyInput.value = match.dosage_quantity;
+            unitSelect.value = match.dosage_unit;
         }
     });
     // Also handle picking from datalist (fires 'change')
     nameInput.addEventListener('change', () => {
         const match = medDosageMap[nameInput.value];
         if (match) {
-            dosageInput.value = match;
+            qtyInput.value = match.dosage_quantity;
+            unitSelect.value = match.dosage_unit;
         }
     });
 }
@@ -793,12 +796,22 @@ function initForms() {
     document.getElementById('medication-form').addEventListener('submit', async (e) => {
         e.preventDefault();
         const name = document.getElementById('med-name').value;
-        const dosage = document.getElementById('med-dosage').value;
+        const dosageQtyRaw = document.getElementById('med-dosage-qty').value;
+        const dosage_unit = document.getElementById('med-dosage-unit').value;
         const notes = document.getElementById('med-notes').value || undefined;
         const timestampInput = document.getElementById('med-timestamp').value;
         const timestamp = timestampInput ? new Date(timestampInput).toISOString() : undefined;
+        const dosage_quantity = parseFloat(parseFloat(dosageQtyRaw).toFixed(2));
+        if (isNaN(dosage_quantity) || dosage_quantity <= 0) {
+            showToast('Quantity must be a positive number');
+            return;
+        }
+        if (!dosage_unit) {
+            showToast('Please select a unit');
+            return;
+        }
         try {
-            await api.post('/api/medications', { medication_name: name, dosage, notes, timestamp });
+            await api.post('/api/medications', { medication_name: name, dosage_quantity, dosage_unit, notes, timestamp });
             closeModal('health-modal');
             showToast('Medication logged!');
             loadDashboard();
@@ -977,14 +990,23 @@ function buildFeedingEditFields(data, secondaryData = null) {
 }
 
 function buildMedicationEditFields(data) {
+    const units = ['mL', 'tsp(s)', 'tbsp(s)', 'drop(s)', 'spray(s)', 'tablet(s)', 'unit(s)'];
+    const unitOptions = units.map(u =>
+        `<option value="${u}" ${data.dosage_unit === u ? 'selected' : ''}>${u}</option>`
+    ).join('');
     return `
         <div class="form-group">
             <label for="edit-med-name">Medication Name</label>
             <input type="text" id="edit-med-name" value="${escapeAttr(data.medication_name)}" required>
         </div>
         <div class="form-group">
-            <label for="edit-med-dosage">Dosage</label>
-            <input type="text" id="edit-med-dosage" value="${escapeAttr(data.dosage)}" required>
+            <label>Dosage</label>
+            <div class="input-group">
+                <input type="number" id="edit-med-dosage-qty" step="0.01" min="0.01" value="${data.dosage_quantity}" required>
+                <select id="edit-med-dosage-unit" required>
+                    ${unitOptions}
+                </select>
+            </div>
         </div>
         <div class="form-group">
             <label for="edit-timestamp">Time</label>
@@ -1059,7 +1081,8 @@ function buildEditBody(type) {
         }
         case 'medication':
             body.medication_name = document.getElementById('edit-med-name').value;
-            body.dosage = document.getElementById('edit-med-dosage').value;
+            body.dosage_quantity = parseFloat(parseFloat(document.getElementById('edit-med-dosage-qty').value).toFixed(2));
+            body.dosage_unit = document.getElementById('edit-med-dosage-unit').value;
             break;
         case 'temperature': {
             let tempValue = parseFloat(document.getElementById('edit-temp-value').value);

--- a/templates/index.html
+++ b/templates/index.html
@@ -196,8 +196,20 @@
                         <datalist id="med-name-suggestions"></datalist>
                     </div>
                     <div class="form-group">
-                        <label for="med-dosage">Dosage</label>
-                        <input type="text" name="dosage" id="med-dosage" required>
+                        <label>Dosage</label>
+                        <div class="input-group">
+                            <input type="number" name="dosage_quantity" id="med-dosage-qty" step="0.01" min="0.01" placeholder="e.g. 1.5" required>
+                            <select name="dosage_unit" id="med-dosage-unit" required>
+                                <option value="">Unit...</option>
+                                <option value="mL">mL</option>
+                                <option value="tsp(s)">tsp(s)</option>
+                                <option value="tbsp(s)">tbsp(s)</option>
+                                <option value="drop(s)">drop(s)</option>
+                                <option value="spray(s)">spray(s)</option>
+                                <option value="tablet(s)">tablet(s)</option>
+                                <option value="unit(s)">unit(s)</option>
+                            </select>
+                        </div>
                     </div>
                     <div class="form-group">
                         <label for="med-timestamp">Time (optional)</label>

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -3,13 +3,15 @@ def test_create_medication(client):
         "/api/medications",
         json={
             "medication_name": "Tylenol",
-            "dosage": "2.5ml",
+            "dosage_quantity": 2.5,
+            "dosage_unit": "mL",
         },
     )
     assert resp.status_code == 201
     data = resp.json()
     assert data["medication_name"] == "Tylenol"
-    assert data["dosage"] == "2.5ml"
+    assert data["dosage_quantity"] == 2.5
+    assert data["dosage_unit"] == "mL"
 
 
 def test_create_medication_with_timestamp(client):
@@ -19,7 +21,8 @@ def test_create_medication_with_timestamp(client):
         "/api/medications",
         json={
             "medication_name": "Tylenol",
-            "dosage": "2.5ml",
+            "dosage_quantity": 2.5,
+            "dosage_unit": "mL",
             "timestamp": custom_time,
         },
     )
@@ -29,8 +32,68 @@ def test_create_medication_with_timestamp(client):
     assert data["timestamp"] == custom_time
 
 
+def test_create_medication_integer_quantity(client):
+    resp = client.post(
+        "/api/medications",
+        json={"medication_name": "Vitamin D", "dosage_quantity": 1, "dosage_unit": "tablet(s)"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["dosage_quantity"] == 1.0
+
+
+def test_create_medication_two_decimal_quantity(client):
+    resp = client.post(
+        "/api/medications",
+        json={"medication_name": "Ibuprofen", "dosage_quantity": 2.25, "dosage_unit": "mL"},
+    )
+    assert resp.status_code == 201
+    assert resp.json()["dosage_quantity"] == 2.25
+
+
+def test_create_medication_invalid_quantity_too_many_decimals(client):
+    resp = client.post(
+        "/api/medications",
+        json={"medication_name": "Tylenol", "dosage_quantity": 1.555, "dosage_unit": "mL"},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_medication_invalid_quantity_zero(client):
+    resp = client.post(
+        "/api/medications",
+        json={"medication_name": "Tylenol", "dosage_quantity": 0, "dosage_unit": "mL"},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_medication_invalid_quantity_negative(client):
+    resp = client.post(
+        "/api/medications",
+        json={"medication_name": "Tylenol", "dosage_quantity": -1.5, "dosage_unit": "mL"},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_medication_invalid_unit(client):
+    resp = client.post(
+        "/api/medications",
+        json={"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "oz"},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_medication_all_valid_units(client):
+    for unit in ["mL", "tsp(s)", "tbsp(s)", "drop(s)", "spray(s)", "tablet(s)", "unit(s)"]:
+        resp = client.post(
+            "/api/medications",
+            json={"medication_name": "Med", "dosage_quantity": 1.0, "dosage_unit": unit},
+        )
+        assert resp.status_code == 201, f"Failed for unit: {unit}"
+        assert resp.json()["dosage_unit"] == unit
+
+
 def test_list_medications(client):
-    client.post("/api/medications", json={"medication_name": "Tylenol", "dosage": "2.5ml"})
+    client.post("/api/medications", json={"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"})
     resp = client.get("/api/medications")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
@@ -41,13 +104,27 @@ def test_update_medication(client):
         "/api/medications",
         json={
             "medication_name": "Tylenol",
-            "dosage": "2.5ml",
+            "dosage_quantity": 2.5,
+            "dosage_unit": "mL",
         },
     )
     mid = create_resp.json()["id"]
-    resp = client.put(f"/api/medications/{mid}", json={"dosage": "5ml"})
+    resp = client.put(f"/api/medications/{mid}", json={"dosage_quantity": 5.0, "dosage_unit": "mL"})
     assert resp.status_code == 200
-    assert resp.json()["dosage"] == "5ml"
+    assert resp.json()["dosage_quantity"] == 5.0
+    assert resp.json()["dosage_unit"] == "mL"
+
+
+def test_update_medication_unit_only(client):
+    create_resp = client.post(
+        "/api/medications",
+        json={"medication_name": "Tylenol", "dosage_quantity": 1.0, "dosage_unit": "mL"},
+    )
+    mid = create_resp.json()["id"]
+    resp = client.put(f"/api/medications/{mid}", json={"dosage_unit": "tsp(s)"})
+    assert resp.status_code == 200
+    assert resp.json()["dosage_unit"] == "tsp(s)"
+    assert resp.json()["dosage_quantity"] == 1.0
 
 
 def test_delete_medication(client):
@@ -55,7 +132,8 @@ def test_delete_medication(client):
         "/api/medications",
         json={
             "medication_name": "Tylenol",
-            "dosage": "2.5ml",
+            "dosage_quantity": 2.5,
+            "dosage_unit": "mL",
         },
     )
     mid = create_resp.json()["id"]
@@ -132,11 +210,38 @@ def test_dashboard_empty(client):
     assert data["last_diaper"] is None
 
 
+def test_medication_detail_in_activities(client):
+    client.post(
+        "/api/medications",
+        json={"medication_name": "Vitamin D", "dosage_quantity": 1.5, "dosage_unit": "mL"},
+    )
+    resp = client.get("/api/dashboard")
+    assert resp.status_code == 200
+    activities = resp.json()["recent_activities"]
+    med_activity = next(a for a in activities if a["type"] == "medication")
+    assert med_activity["detail"] == "1.50 mL"
+    assert med_activity["label"] == "Vitamin D"
+
+
 def test_export_csv(client):
     client.post("/api/diapers", json={"type": "pee"})
     resp = client.get("/api/export?format=csv")
     assert resp.status_code == 200
     assert "text/csv" in resp.headers["content-type"]
+
+
+def test_export_csv_medication_columns(client):
+    client.post(
+        "/api/medications",
+        json={"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"},
+    )
+    resp = client.get("/api/export?format=csv")
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert "dosage_quantity" in content
+    assert "dosage_unit" in content
+    assert "2.5" in content
+    assert "mL" in content
 
 
 def test_export_json(client):


### PR DESCRIPTION
Replaces the free-text dosage field with a numeric quantity (float, max
2 decimal places) and a predefined unit dropdown (mL, tsp(s), tbsp(s),
drop(s), spray(s), tablet(s), unit(s)).

- Adds DosageUnit enum and updates Medication model, schemas, CRUD, and
  API endpoints accordingly
- Adds a DB migration that adds the two new columns and attempts to
  parse existing free-text dosage values into the structured fields
- Updates the Health modal UI to show a quantity input + unit select
- Updates activity display to render as "1.50 mL" format
- Updates PDF/CSV exports to use the new columns
- Updates all medication tests; adds validation tests for quantity rules

Closes #26

https://claude.ai/code/session_013Kf9n6roGnuz7SJGf7NLkN