### PR TITLE
Add medication name autocomplete with per-user saved list (issue #27)

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from sqlalchemy import String, cast, func, select
 from sqlalchemy.orm import Session
 
-from puffin.models import DiaperChange, Feeding, Medication, TemperatureReading
+from puffin.models import DiaperChange, Feeding, Medication, SavedMedication, TemperatureReading
 
 # --- Generic helpers ---
 
@@ -287,6 +287,22 @@ def medication_stats(db: Session) -> dict[str, int]:
         "week": _period_count(db, Medication, Medication.timestamp, "week"),
         "month": _period_count(db, Medication, Medication.timestamp, "month"),
     }
+
+
+def get_saved_medications(db: Session) -> list[str]:
+    """Return saved medication names sorted case-insensitively A→Z."""
+    stmt = select(SavedMedication.name).order_by(func.lower(SavedMedication.name))
+    return list(db.execute(stmt).scalars().all())
+
+
+def add_saved_medication(db: Session, name: str) -> bool:
+    """Add name to saved list if no case-insensitive match exists. Returns True if added."""
+    stmt = select(SavedMedication).where(func.lower(SavedMedication.name) == name.lower())
+    if db.execute(stmt).scalar_one_or_none() is not None:
+        return False
+    db.add(SavedMedication(name=name))
+    db.commit()
+    return True
 
 
 # --- Temperature Readings ---

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -117,6 +117,25 @@ def _run_migrations(bind=None) -> None:
                 )
             conn.commit()
 
+        # Seed saved_medications from existing medication log entries (first casing wins)
+        if insp.has_table("saved_medications"):
+            saved_count = conn.execute(text("SELECT COUNT(*) FROM saved_medications")).scalar()
+            if saved_count == 0:
+                rows = conn.execute(
+                    text("SELECT medication_name FROM medications ORDER BY timestamp ASC, id ASC")
+                ).fetchall()
+                seen_lower: set[str] = set()
+                for (name,) in rows:
+                    lower = name.lower()
+                    if lower not in seen_lower:
+                        seen_lower.add(lower)
+                        conn.execute(
+                            text("INSERT OR IGNORE INTO saved_medications (name) VALUES (:name)"),
+                            {"name": name},
+                        )
+                if seen_lower:
+                    conn.commit()
+
 
 def init_db():
     """Create all tables, disposing stale connections first."""

--- a/src/puffin/models.py
+++ b/src/puffin/models.py
@@ -86,3 +86,11 @@ class TemperatureReading(Base):
     created_at: Mapped[datetime] = mapped_column(_TZ_DATETIME, default=_utcnow)
 
     __table_args__ = (Index("idx_temperature_timestamp", "timestamp"),)
+
+
+class SavedMedication(Base):
+    __tablename__ = "saved_medications"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String, nullable=False, unique=True)
+    created_at: Mapped[datetime] = mapped_column(_TZ_DATETIME, default=_utcnow)

--- a/src/puffin/routers/health.py
+++ b/src/puffin/routers/health.py
@@ -24,7 +24,7 @@ router = APIRouter(tags=["health"])
 
 @router.post("/api/medications", response_model=MedicationResponse, status_code=201)
 def create_medication(data: MedicationCreate, db: Session = Depends(get_db)):
-    return crud.create_medication(
+    result = crud.create_medication(
         db,
         timestamp=data.timestamp,
         medication_name=data.medication_name,
@@ -32,6 +32,13 @@ def create_medication(data: MedicationCreate, db: Session = Depends(get_db)):
         dosage_unit=data.dosage_unit.value,
         notes=data.notes,
     )
+    crud.add_saved_medication(db, data.medication_name)
+    return result
+
+
+@router.get("/api/medications/saved-names", response_model=list[str])
+def list_saved_medication_names(db: Session = Depends(get_db)):
+    return crud.get_saved_medications(db)
 
 
 @router.get("/api/medications", response_model=list[MedicationResponse])

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -519,6 +519,98 @@ body {
     border-color: var(--primary);
 }
 
+/* Medication name autocomplete */
+.med-autocomplete {
+    position: relative;
+}
+
+.med-name-input {
+    width: 100%;
+    padding: 10px 14px;
+    font-size: 1rem;
+    font-family: inherit;
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    outline: none;
+    transition: border-color 0.15s ease;
+}
+
+.med-name-input:focus {
+    border-color: var(--primary);
+}
+
+.med-chip-display {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px;
+    background: var(--primary);
+    color: #fff;
+    border-radius: var(--radius-sm);
+    font-size: 0.95rem;
+    min-height: 42px;
+}
+
+.med-chip-display.hidden { display: none; }
+
+.med-chip-text {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.med-chip-dismiss {
+    background: none;
+    border: none;
+    color: #fff;
+    cursor: pointer;
+    font-size: 1.2rem;
+    line-height: 1;
+    padding: 0 2px;
+    opacity: 0.85;
+    flex-shrink: 0;
+}
+
+.med-chip-dismiss:hover { opacity: 1; }
+
+.med-dropdown {
+    position: absolute;
+    top: calc(100% + 2px);
+    left: 0;
+    right: 0;
+    z-index: 200;
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-sm);
+    max-height: 220px;
+    overflow-y: auto;
+    box-shadow: var(--shadow-lg);
+}
+
+.med-dropdown.hidden { display: none; }
+
+.med-dropdown-item {
+    padding: 10px 14px;
+    cursor: pointer;
+    font-size: 0.95rem;
+    color: var(--text-primary);
+    transition: background 0.1s ease;
+}
+
+.med-dropdown-item:hover,
+.med-dropdown-item.focused {
+    background: var(--bg-secondary);
+}
+
+.med-dropdown-item.add-new {
+    color: var(--primary);
+    font-weight: 500;
+    border-top: 1px solid var(--border);
+}
+
 .input-group {
     display: flex;
     gap: 8px;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -103,7 +103,8 @@ function openModal(id) {
     } else if (id === 'diaper-modal') {
         loadNoteSuggestions('/api/diapers', 'diaper-note-suggestions', 'diaper-notes');
     } else if (id === 'health-modal') {
-        loadMedSuggestions();
+        loadSavedMedNames();
+        loadMedDosageMap();
         loadNoteSuggestions('/api/medications', 'med-note-suggestions', 'med-notes');
         loadNoteSuggestions('/api/temperatures', 'temp-note-suggestions', 'temp-notes');
     }
@@ -116,6 +117,9 @@ function closeModal(id) {
     forms.forEach(f => f.reset());
     // Clear selected buttons
     document.getElementById(id).querySelectorAll('.btn-option.selected').forEach(b => b.classList.remove('selected'));
+    if (id === 'health-modal') {
+        resetMedAutocomplete();
+    }
     // Reset feeding modal to timer mode
     if (id === 'feeding-modal') {
         document.getElementById('feeding-timer-mode').classList.remove('hidden');
@@ -607,47 +611,132 @@ function initFeedingForm() {
     updateMode();
 }
 
-/* ===== Auto-fill Suggestions ===== */
-let medDosageMap = {}; // medication_name -> { dosage_quantity, dosage_unit }
+/* ===== Medication Autocomplete ===== */
+let savedMedNames = []; // sorted A→Z from /api/medications/saved-names
+let medDosageMap = {};  // name -> { dosage_quantity, dosage_unit } from recent logs
 
-async function loadMedSuggestions() {
+async function loadSavedMedNames() {
     try {
-        const meds = await api.get('/api/medications?limit=50');
-        const datalist = document.getElementById('med-name-suggestions');
-        medDosageMap = {};
-        const seen = new Set();
-        // meds are sorted newest-first, so first occurrence = most recent dosage
-        for (const m of meds) {
-            const name = m.medication_name;
-            if (!seen.has(name)) {
-                seen.add(name);
-                medDosageMap[name] = { dosage_quantity: m.dosage_quantity, dosage_unit: m.dosage_unit };
-            }
-        }
-        datalist.innerHTML = [...seen].map(n => `<option value="${escapeAttr(n)}">`).join('');
+        savedMedNames = await api.get('/api/medications/saved-names');
     } catch (e) {
-        console.error('Failed to load medication suggestions:', e);
+        console.error('Failed to load saved medication names:', e);
+        savedMedNames = [];
     }
 }
 
-function initMedAutoFill() {
-    const nameInput = document.getElementById('med-name');
+async function loadMedDosageMap() {
+    try {
+        const meds = await api.get('/api/medications?limit=50');
+        medDosageMap = {};
+        const seen = new Set();
+        for (const m of meds) {
+            const name = m.medication_name;
+            if (!seen.has(name.toLowerCase())) {
+                seen.add(name.toLowerCase());
+                medDosageMap[name.toLowerCase()] = { dosage_quantity: m.dosage_quantity, dosage_unit: m.dosage_unit };
+            }
+        }
+    } catch (e) {
+        console.error('Failed to load medication dosage map:', e);
+    }
+}
+
+function resetMedAutocomplete() {
+    const chipDisplay = document.getElementById('med-chip-display');
+    const nameInput = document.getElementById('med-name-input');
+    const hiddenInput = document.getElementById('med-name');
+    const dropdown = document.getElementById('med-dropdown');
+    chipDisplay.classList.add('hidden');
+    nameInput.classList.remove('hidden');
+    nameInput.value = '';
+    hiddenInput.value = '';
+    dropdown.classList.add('hidden');
+    dropdown.innerHTML = '';
+}
+
+function selectMedName(name) {
+    const chipDisplay = document.getElementById('med-chip-display');
+    const chipText = document.getElementById('med-chip-text');
+    const nameInput = document.getElementById('med-name-input');
+    const hiddenInput = document.getElementById('med-name');
+    const dropdown = document.getElementById('med-dropdown');
+
+    chipText.textContent = name;
+    hiddenInput.value = name;
+    chipDisplay.classList.remove('hidden');
+    nameInput.classList.add('hidden');
+    dropdown.classList.add('hidden');
+    dropdown.innerHTML = '';
+
+    // Auto-fill dosage if fields are empty
     const qtyInput = document.getElementById('med-dosage-qty');
     const unitSelect = document.getElementById('med-dosage-unit');
-    nameInput.addEventListener('input', () => {
-        const match = medDosageMap[nameInput.value];
-        if (match && !qtyInput.value) {
-            qtyInput.value = match.dosage_quantity;
-            unitSelect.value = match.dosage_unit;
-        }
+    const match = medDosageMap[name.toLowerCase()];
+    if (match && !qtyInput.value) {
+        qtyInput.value = match.dosage_quantity;
+        unitSelect.value = match.dosage_unit;
+    }
+}
+
+function renderMedDropdown(query) {
+    const dropdown = document.getElementById('med-dropdown');
+    const q = query.trim().toLowerCase();
+    let matches;
+    if (q === '') {
+        matches = savedMedNames;
+    } else {
+        matches = savedMedNames.filter(n => n.toLowerCase().includes(q));
+    }
+
+    const items = [];
+    for (const name of matches) {
+        items.push(`<div class="med-dropdown-item" role="option" data-name="${escapeAttr(name)}">${escapeHtml(name)}</div>`);
+    }
+
+    // Show "+ Add" only when query is non-empty and no exact case-insensitive match exists
+    const hasExact = savedMedNames.some(n => n.toLowerCase() === q);
+    if (q !== '' && !hasExact) {
+        items.push(`<div class="med-dropdown-item add-new" role="option" data-add="${escapeAttr(query.trim())}">+ Add &ldquo;${escapeHtml(query.trim())}&rdquo;</div>`);
+    }
+
+    if (items.length === 0) {
+        dropdown.classList.add('hidden');
+        return;
+    }
+
+    dropdown.innerHTML = items.join('');
+    dropdown.classList.remove('hidden');
+
+    dropdown.querySelectorAll('.med-dropdown-item').forEach(el => {
+        el.addEventListener('mousedown', (e) => {
+            e.preventDefault(); // prevent blur before click
+            const name = el.dataset.name || el.dataset.add;
+            selectMedName(name);
+        });
     });
-    // Also handle picking from datalist (fires 'change')
-    nameInput.addEventListener('change', () => {
-        const match = medDosageMap[nameInput.value];
-        if (match) {
-            qtyInput.value = match.dosage_quantity;
-            unitSelect.value = match.dosage_unit;
-        }
+}
+
+function initMedAutocomplete() {
+    const nameInput = document.getElementById('med-name-input');
+    const dropdown = document.getElementById('med-dropdown');
+    const dismissBtn = document.getElementById('med-chip-dismiss');
+
+    nameInput.addEventListener('focus', () => {
+        renderMedDropdown(nameInput.value);
+    });
+
+    nameInput.addEventListener('input', () => {
+        renderMedDropdown(nameInput.value);
+    });
+
+    nameInput.addEventListener('blur', () => {
+        // Small delay so mousedown on dropdown items can fire first
+        setTimeout(() => dropdown.classList.add('hidden'), 150);
+    });
+
+    dismissBtn.addEventListener('click', () => {
+        resetMedAutocomplete();
+        document.getElementById('med-name-input').focus();
     });
 }
 
@@ -795,7 +884,12 @@ function initForms() {
     // Medication form
     document.getElementById('medication-form').addEventListener('submit', async (e) => {
         e.preventDefault();
-        const name = document.getElementById('med-name').value;
+        const name = document.getElementById('med-name').value.trim();
+        if (!name) {
+            showToast('Please select or add a medication name');
+            document.getElementById('med-name-input').focus();
+            return;
+        }
         const dosageQtyRaw = document.getElementById('med-dosage-qty').value;
         const dosage_unit = document.getElementById('med-dosage-unit').value;
         const notes = document.getElementById('med-notes').value || undefined;
@@ -1419,7 +1513,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initTimer();
     initFeedingForm();
     initForms();
-    initMedAutoFill();
+    initMedAutocomplete();
     initEditForm();
     initCalendar();
     initSettings();

--- a/templates/index.html
+++ b/templates/index.html
@@ -191,9 +191,16 @@
             <div id="med-tab" class="tab-content active">
                 <form id="medication-form">
                     <div class="form-group">
-                        <label for="med-name">Medication Name</label>
-                        <input type="text" name="medication_name" id="med-name" list="med-name-suggestions" autocomplete="off" required>
-                        <datalist id="med-name-suggestions"></datalist>
+                        <label>Medication Name</label>
+                        <div class="med-autocomplete" id="med-autocomplete">
+                            <div class="med-chip-display hidden" id="med-chip-display">
+                                <span class="med-chip-text" id="med-chip-text"></span>
+                                <button type="button" class="med-chip-dismiss" id="med-chip-dismiss" aria-label="Clear">×</button>
+                            </div>
+                            <input type="text" id="med-name-input" class="med-name-input" autocomplete="off" placeholder="Type medication name…">
+                            <div class="med-dropdown hidden" id="med-dropdown" role="listbox"></div>
+                        </div>
+                        <input type="hidden" id="med-name" name="medication_name">
                     </div>
                     <div class="form-group">
                         <label>Dosage</label>

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -301,3 +301,56 @@ def test_export_pdf_with_date_range(client):
     resp = client.get(url)
     assert resp.status_code == 200
     assert resp.headers["content-type"] == "application/pdf"
+
+
+# --- Saved medication names ---
+
+
+def test_saved_names_empty(client):
+    resp = client.get("/api/medications/saved-names")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_saved_names_added_on_create(client):
+    client.post(
+        "/api/medications",
+        json={"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"},
+    )
+    resp = client.get("/api/medications/saved-names")
+    assert resp.status_code == 200
+    assert resp.json() == ["Tylenol"]
+
+
+def test_saved_names_sorted_case_insensitively(client):
+    for name in ["vitamin C", "Tylenol", "ibuprofen"]:
+        client.post(
+            "/api/medications",
+            json={"medication_name": name, "dosage_quantity": 1.0, "dosage_unit": "mL"},
+        )
+    resp = client.get("/api/medications/saved-names")
+    assert resp.status_code == 200
+    assert resp.json() == ["ibuprofen", "Tylenol", "vitamin C"]
+
+
+def test_saved_names_no_case_insensitive_duplicates(client):
+    for name in ["Vitamin D", "vitamin d", "VITAMIN D"]:
+        client.post(
+            "/api/medications",
+            json={"medication_name": name, "dosage_quantity": 1.0, "dosage_unit": "tablet(s)"},
+        )
+    resp = client.get("/api/medications/saved-names")
+    assert resp.status_code == 200
+    names = resp.json()
+    assert len(names) == 1
+    # First casing submitted is preserved
+    assert names[0] == "Vitamin D"
+
+
+def test_saved_names_preserves_original_casing(client):
+    client.post(
+        "/api/medications",
+        json={"medication_name": "vitamin C", "dosage_quantity": 1.0, "dosage_unit": "tablet(s)"},
+    )
+    resp = client.get("/api/medications/saved-names")
+    assert resp.json() == ["vitamin C"]


### PR DESCRIPTION
- Add SavedMedication model (saved_medications table) with case-insensitive
  unique constraint enforced at the application level
- Migration seeds the saved list from existing medication log entries on first
  startup, preserving the first casing encountered per case-insensitive name
- POST /api/medications now adds the medication name to the saved list on
  successful save; duplicate names (case-insensitive) are silently ignored
- New GET /api/medications/saved-names endpoint returns names sorted A→Z
- Replace the datalist-based Medication Name input with a custom autocomplete:
  - On focus shows the full saved list; filters in real time as the user types
  - Selecting an entry or clicking "+ Add …" creates a single chip; only one
    chip is allowed at a time; the × dismiss button restores the text input
  - "+ Add …" appears only when the typed text has no case-insensitive match
    in the saved list; this prevents duplicate variations
  - Dosage auto-fill still works when a medication is selected via the chip
- Modal close/cancel discards pending additions (chip is cleared; name is not
  committed until the log entry is saved)

https://claude.ai/code/session_019DsjjxsvJe3kkCsDBJKJKv