### PR TITLE
Add bottle type tracking for feeding logs

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -114,6 +114,7 @@ def create_feeding(
     amount_oz: float | None,
     notes: str | None,
     session_id: str | None = None,
+    bottle_type: str | None = None,
 ) -> Feeding:
     obj = Feeding(
         timestamp=timestamp or datetime.now(UTC),
@@ -122,6 +123,7 @@ def create_feeding(
         amount_oz=amount_oz,
         notes=notes,
         session_id=session_id,
+        bottle_type=bottle_type,
     )
     db.add(obj)
     db.commit()
@@ -447,7 +449,8 @@ def get_activities(
             session_groups.setdefault(f.session_id, []).append(f)
         else:
             if f.amount_oz:
-                detail = f"{f.amount_oz} oz"
+                bottle_label = "Formula" if f.bottle_type == "formula" else "Breastmilk"
+                detail = f"{bottle_label} · {f.amount_oz} oz"
             elif f.duration_minutes:
                 detail = f"{f.duration_minutes} min"
             else:

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -92,6 +92,9 @@ def _run_migrations(bind=None) -> None:
         if "session_id" not in existing_cols:
             conn.execute(text("ALTER TABLE feedings ADD COLUMN session_id TEXT"))
             conn.commit()
+        if "bottle_type" not in existing_cols:
+            conn.execute(text("ALTER TABLE feedings ADD COLUMN bottle_type TEXT"))
+            conn.commit()
 
         insp = inspect(conn)
         if not insp.has_table("medications"):

--- a/src/puffin/models.py
+++ b/src/puffin/models.py
@@ -54,6 +54,7 @@ class Feeding(Base):
     amount_oz: Mapped[float | None] = mapped_column(Float, nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     session_id: Mapped[str | None] = mapped_column(String, nullable=True)
+    bottle_type: Mapped[str | None] = mapped_column(String, nullable=True)  # breastmilk, formula
     created_at: Mapped[datetime] = mapped_column(_TZ_DATETIME, default=_utcnow)
 
     __table_args__ = (Index("idx_feeding_timestamp", "timestamp"),)

--- a/src/puffin/routers/feedings.py
+++ b/src/puffin/routers/feedings.py
@@ -20,6 +20,7 @@ def create_feeding(data: FeedingCreate, db: Session = Depends(get_db)):
         amount_oz=data.amount_oz,
         notes=data.notes,
         session_id=data.session_id,
+        bottle_type=data.bottle_type.value if data.bottle_type else None,
     )
 
 
@@ -62,6 +63,8 @@ def update_feeding(feeding_id: int, data: FeedingUpdate, db: Session = Depends(g
         updates["amount_oz"] = data.amount_oz
     if data.notes is not None:
         updates["notes"] = data.notes
+    if data.bottle_type is not None:
+        updates["bottle_type"] = data.bottle_type.value
     obj = crud.update_feeding(db, feeding_id, **updates)
     if not obj:
         raise HTTPException(status_code=404, detail="Feeding not found")

--- a/src/puffin/schemas.py
+++ b/src/puffin/schemas.py
@@ -20,6 +20,11 @@ class FeedingType(StrEnum):
     bottle = "bottle"
 
 
+class BottleType(StrEnum):
+    breastmilk = "breastmilk"
+    formula = "formula"
+
+
 class TemperatureLocation(StrEnum):
     rectal = "rectal"
     oral = "oral"
@@ -72,6 +77,7 @@ class FeedingCreate(BaseModel):
     amount_oz: float | None = None
     notes: str | None = None
     session_id: str | None = None
+    bottle_type: BottleType | None = None
 
 
 class FeedingUpdate(BaseModel):
@@ -80,6 +86,7 @@ class FeedingUpdate(BaseModel):
     duration_minutes: int | None = None
     amount_oz: float | None = None
     notes: str | None = None
+    bottle_type: BottleType | None = None
 
 
 class FeedingResponse(BaseModel):
@@ -92,6 +99,7 @@ class FeedingResponse(BaseModel):
     amount_oz: float | None
     notes: str | None
     session_id: str | None
+    bottle_type: BottleType | None
     created_at: datetime
 
 

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -46,6 +46,30 @@ const BREAST_RIGHT_KEY = 'puffin-breast-right-name';
 const DEFAULT_LEFT_NAME = 'Left';
 const DEFAULT_RIGHT_NAME = 'Right';
 
+/* ===== Bottle Type ===== */
+const BOTTLE_TYPE_KEY = 'puffin-bottle-type-default';
+const DEFAULT_BOTTLE_TYPE = 'breastmilk';
+
+function getDefaultBottleType() {
+    return localStorage.getItem(BOTTLE_TYPE_KEY) || DEFAULT_BOTTLE_TYPE;
+}
+
+function updateBottleTypeLabels() {
+    const defaultType = getDefaultBottleType();
+    const selects = [
+        document.getElementById('feeding-bottle-type-timer-select'),
+        document.getElementById('feeding-bottle-type-manual-select'),
+    ];
+    for (const sel of selects) {
+        if (!sel) continue;
+        sel.querySelector('option[value="breastmilk"]').textContent =
+            'Breastmilk' + (defaultType === 'breastmilk' ? ' (default)' : '');
+        sel.querySelector('option[value="formula"]').textContent =
+            'Formula' + (defaultType === 'formula' ? ' (default)' : '');
+        sel.value = defaultType;
+    }
+}
+
 function getBreastNames() {
     return {
         left: localStorage.getItem(BREAST_LEFT_KEY) || DEFAULT_LEFT_NAME,
@@ -100,6 +124,7 @@ function openModal(id) {
     if (id === 'feeding-modal') {
         loadLastBreastFeeding();
         loadNoteSuggestions('/api/feedings', 'feeding-note-suggestions', 'feeding-notes');
+        updateBottleTypeLabels();
     } else if (id === 'diaper-modal') {
         loadNoteSuggestions('/api/diapers', 'diaper-note-suggestions', 'diaper-notes');
     } else if (id === 'health-modal') {
@@ -804,10 +829,12 @@ function initForms() {
             if (feedingType === 'bottle') {
                 const oz = document.getElementById('feeding-bottle-oz-timer-input').value;
                 if (!oz) { showToast('Please enter ounces'); return; }
+                const bottleType = document.getElementById('feeding-bottle-type-timer-select').value;
                 try {
                     await api.post('/api/feedings', {
                         feeding_type: 'bottle',
                         amount_oz: parseFloat(oz),
+                        bottle_type: bottleType,
                         notes,
                         timestamp,
                     });
@@ -865,9 +892,11 @@ function initForms() {
                 notesAttached = true;
             }
             if (bottleOz) {
+                const bottleType = document.getElementById('feeding-bottle-type-manual-select').value;
                 promises.push(api.post('/api/feedings', {
                     feeding_type: 'bottle',
                     amount_oz: parseFloat(bottleOz),
+                    bottle_type: bottleType,
                     notes: notesAttached ? undefined : notes,
                     timestamp,
                 }));
@@ -1054,6 +1083,7 @@ function buildFeedingEditFields(data, secondaryData = null) {
     }
     const isBottle = data.feeding_type === 'bottle';
     const names = getBreastNames();
+    const bottleTypeVal = data.bottle_type || 'breastmilk';
     return `
         <div class="form-group">
             <label>Type</label>
@@ -1071,6 +1101,13 @@ function buildFeedingEditFields(data, secondaryData = null) {
         <div class="form-group" id="edit-oz-group" ${isBottle ? '' : 'style="display:none"'}>
             <label for="edit-amount-oz">Amount (oz)</label>
             <input type="number" id="edit-amount-oz" min="0.5" max="12" step="0.5" value="${data.amount_oz || ''}">
+        </div>
+        <div class="form-group" id="edit-bottle-type-group" ${isBottle ? '' : 'style="display:none"'}>
+            <label for="edit-bottle-type">Bottle Type</label>
+            <select id="edit-bottle-type">
+                <option value="breastmilk" ${bottleTypeVal === 'breastmilk' ? 'selected' : ''}>Breastmilk</option>
+                <option value="formula" ${bottleTypeVal === 'formula' ? 'selected' : ''}>Formula</option>
+            </select>
         </div>
         <div class="form-group">
             <label for="edit-timestamp">Time</label>
@@ -1167,6 +1204,8 @@ function buildEditBody(type) {
             if (body.feeding_type === 'bottle') {
                 const oz = document.getElementById('edit-amount-oz').value;
                 if (oz) body.amount_oz = parseFloat(oz);
+                const btEl = document.getElementById('edit-bottle-type');
+                if (btEl) body.bottle_type = btEl.value;
             } else {
                 const dur = document.getElementById('edit-duration').value;
                 if (dur) body.duration_minutes = parseInt(dur);
@@ -1200,14 +1239,16 @@ function initEditOptionButtons() {
             btn.classList.add('selected');
             document.getElementById(field).value = value;
 
-            // Toggle duration vs ounces for feeding edits
+            // Toggle duration vs ounces/bottle-type for feeding edits
             if (field === 'edit-feeding-type') {
                 const durGroup = document.getElementById('edit-duration-group');
                 const ozGroup = document.getElementById('edit-oz-group');
+                const btGroup = document.getElementById('edit-bottle-type-group');
                 if (durGroup && ozGroup) {
                     durGroup.style.display = value === 'bottle' ? 'none' : '';
                     ozGroup.style.display = value === 'bottle' ? '' : 'none';
                 }
+                if (btGroup) btGroup.style.display = value === 'bottle' ? '' : 'none';
             }
         });
     });
@@ -1468,6 +1509,7 @@ function initSettings() {
         const names = getBreastNames();
         document.getElementById('settings-left-name').value = names.left;
         document.getElementById('settings-right-name').value = names.right;
+        document.getElementById('settings-bottle-type').value = getDefaultBottleType();
         openModal('settings-modal');
     });
 
@@ -1475,10 +1517,13 @@ function initSettings() {
         e.preventDefault();
         const leftName = document.getElementById('settings-left-name').value.trim() || DEFAULT_LEFT_NAME;
         const rightName = document.getElementById('settings-right-name').value.trim() || DEFAULT_RIGHT_NAME;
+        const bottleType = document.getElementById('settings-bottle-type').value;
         localStorage.setItem(BREAST_LEFT_KEY, leftName);
         localStorage.setItem(BREAST_RIGHT_KEY, rightName);
+        localStorage.setItem(BOTTLE_TYPE_KEY, bottleType);
         closeModal('settings-modal');
         updateBreastLabels();
+        updateBottleTypeLabels();
         if (getTimerState()) showTimerUI();
         showToast('Settings saved!');
     });
@@ -1519,6 +1564,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initSettings();
     initExport();
     updateBreastLabels();
+    updateBottleTypeLabels();
     loadDashboard();
 
     // Theme toggle

--- a/templates/index.html
+++ b/templates/index.html
@@ -140,8 +140,14 @@
                         <input type="hidden" id="feeding-type">
                     </div>
                     <div id="feeding-bottle-oz-timer" class="form-group hidden">
-                        <label for="feeding-bottle-oz-timer-input">Amount (oz)</label>
-                        <input type="number" id="feeding-bottle-oz-timer-input" min="0.5" max="12" step="0.5">
+                        <label>Amount &amp; Type</label>
+                        <div class="input-group">
+                            <input type="number" id="feeding-bottle-oz-timer-input" min="0.5" max="12" step="0.5" placeholder="oz">
+                            <select id="feeding-bottle-type-timer-select">
+                                <option value="breastmilk">Breastmilk (default)</option>
+                                <option value="formula">Formula</option>
+                            </select>
+                        </div>
                     </div>
                 </div>
 
@@ -156,8 +162,14 @@
                         <input type="number" id="feeding-right-duration" min="1" max="120">
                     </div>
                     <div class="form-group">
-                        <label for="feeding-bottle-oz">🍼 Bottle (oz)</label>
-                        <input type="number" id="feeding-bottle-oz" min="0.5" max="12" step="0.5">
+                        <label>🍼 Bottle</label>
+                        <div class="input-group">
+                            <input type="number" id="feeding-bottle-oz" min="0.5" max="12" step="0.5" placeholder="oz">
+                            <select id="feeding-bottle-type-manual-select">
+                                <option value="breastmilk">Breastmilk (default)</option>
+                                <option value="formula">Formula</option>
+                            </select>
+                        </div>
                     </div>
                 </div>
 
@@ -303,6 +315,14 @@
                 <div class="form-group">
                     <label for="settings-right-name">Right breast name</label>
                     <input type="text" id="settings-right-name" maxlength="30" placeholder="Right">
+                </div>
+                <h3 class="settings-section-title">Feeding Defaults</h3>
+                <div class="form-group">
+                    <label for="settings-bottle-type">Default bottle type</label>
+                    <select id="settings-bottle-type">
+                        <option value="breastmilk">Breastmilk</option>
+                        <option value="formula">Formula</option>
+                    </select>
                 </div>
                 <div class="form-actions">
                     <button type="submit" class="btn btn-primary btn-lg">Save</button>


### PR DESCRIPTION
## Summary
This PR adds the ability to track and distinguish between breastmilk and formula when logging bottle feedings. Users can now specify the bottle type when creating or editing feeding entries, and set a default bottle type in settings.

## Key Changes

- **Database & Models**: Added `bottle_type` column to the `Feeding` model to store whether a bottle feeding was breastmilk or formula
- **API Schemas**: Created `BottleType` enum and updated `FeedingCreate` and `FeedingUpdate` schemas to include the `bottle_type` field
- **API Endpoints**: Updated feeding creation and update endpoints to handle and persist bottle type data
- **Frontend UI**: 
  - Added bottle type dropdown selectors to both timer and manual feeding entry forms
  - Added bottle type field to the feeding edit modal
  - Integrated bottle type selection with feeding type toggle logic
- **Settings**: Added a "Default bottle type" setting that users can configure, with the default being "breastmilk"
- **Activity Display**: Updated the activity feed to show bottle type label (e.g., "Formula · 4 oz" or "Breastmilk · 4 oz") alongside the amount
- **Label Management**: Implemented `updateBottleTypeLabels()` function to dynamically update dropdown labels to indicate the current default, similar to existing breast name customization

## Implementation Details

- Bottle type defaults to "breastmilk" if not specified
- The default bottle type is persisted in localStorage and can be changed in settings
- When editing a feeding, the bottle type field only appears when the feeding type is set to "bottle"
- The activity feed clearly distinguishes between formula and breastmilk feedings in the detail text

https://claude.ai/code/session_01BvYBczWfrjANPh6CWAo5tQ