### PR TITLE
Fix medication save 500 and empty autocomplete post-migration (#30)

### DIFF
--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -1,5 +1,6 @@
 import os
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 
 from sqlalchemy import create_engine, inspect, text
@@ -120,6 +121,14 @@ def _run_migrations(bind=None) -> None:
                 )
             conn.commit()
 
+        # Drop the obsolete NOT NULL ``dosage`` column if it is still lingering.
+        # ORM INSERTs don't supply ``dosage``, so leaving it in place causes
+        # every new medication save to fail with a NOT NULL constraint error.
+        med_cols = {c["name"] for c in inspect(conn).get_columns("medications")}
+        if "dosage" in med_cols:
+            conn.execute(text("ALTER TABLE medications DROP COLUMN dosage"))
+            conn.commit()
+
         # Seed saved_medications from existing medication log entries (first casing wins)
         if insp.has_table("saved_medications"):
             saved_count = conn.execute(text("SELECT COUNT(*) FROM saved_medications")).scalar()
@@ -128,13 +137,21 @@ def _run_migrations(bind=None) -> None:
                     text("SELECT medication_name FROM medications ORDER BY timestamp ASC, id ASC")
                 ).fetchall()
                 seen_lower: set[str] = set()
+                now = datetime.now(UTC)
                 for (name,) in rows:
                     lower = name.lower()
                     if lower not in seen_lower:
                         seen_lower.add(lower)
+                        # ``created_at`` is NOT NULL at the SQL level but only has
+                        # a Python-side default, so raw INSERTs must populate it
+                        # explicitly — without it, INSERT OR IGNORE would silently
+                        # skip every row.
                         conn.execute(
-                            text("INSERT OR IGNORE INTO saved_medications (name) VALUES (:name)"),
-                            {"name": name},
+                            text(
+                                "INSERT OR IGNORE INTO saved_medications (name, created_at) "
+                                "VALUES (:name, :created_at)"
+                            ),
+                            {"name": name, "created_at": now},
                         )
                 if seen_lower:
                     conn.commit()

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -1,0 +1,155 @@
+"""Tests for ``_run_migrations`` against legacy database schemas.
+
+These tests simulate the schema that existed before the medication-dosage
+split (issue #26) and autocomplete feature (issue #27) to guarantee that a
+user upgrading from an older release still ends up with:
+
+- ``dosage_quantity`` / ``dosage_unit`` columns populated from the old
+  free-text ``dosage`` field.
+- The obsolete NOT NULL ``dosage`` column dropped — otherwise every new
+  medication save would fail with a ``NOT NULL constraint`` error.
+- ``saved_medications`` seeded from prior log entries so the autocomplete
+  dropdown is non-empty on first use.
+"""
+import sqlite3
+
+import pytest
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.pool import StaticPool
+
+from puffin import models  # noqa: F401  (register ORM models on Base.metadata)
+from puffin.database import Base, _run_migrations
+
+
+def _legacy_schema_sql() -> str:
+    """The medications table as it existed before issue #26 — single
+    free-text ``dosage`` column, no ``saved_medications`` table.  Other
+    tables are included because ``_run_migrations`` touches ``feedings``.
+    """
+    return """
+    CREATE TABLE diaper_changes (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp DATETIME NOT NULL, type TEXT NOT NULL,
+        notes TEXT, created_at DATETIME);
+    CREATE TABLE feedings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp DATETIME NOT NULL, feeding_type TEXT NOT NULL,
+        duration_minutes INTEGER, amount_oz REAL,
+        notes TEXT, created_at DATETIME);
+    CREATE TABLE medications (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp DATETIME NOT NULL, medication_name TEXT NOT NULL,
+        dosage TEXT NOT NULL, notes TEXT, created_at DATETIME);
+    CREATE TABLE temperature_readings (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        timestamp DATETIME NOT NULL, temperature_celsius REAL NOT NULL,
+        location TEXT, notes TEXT, created_at DATETIME);
+    """
+
+
+@pytest.fixture
+def legacy_engine(tmp_path):
+    """A file-backed engine whose DB file starts with the pre-#26 schema."""
+    db_path = tmp_path / "legacy.db"
+    raw = sqlite3.connect(db_path)
+    raw.executescript(_legacy_schema_sql())
+    raw.executemany(
+        "INSERT INTO medications (timestamp, medication_name, dosage, notes, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        [
+            ("2026-04-01 10:00:00", "Tylenol", "2.5 ml", None, "2026-04-01 10:00:00"),
+            ("2026-04-02 10:00:00", "Vitamin D", "400 IU (1 drop)", None, "2026-04-02 10:00:00"),
+            ("2026-04-03 10:00:00", "tylenol", "2.5 ml", None, "2026-04-03 10:00:00"),
+        ],
+    )
+    raw.commit()
+    raw.close()
+
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    Base.metadata.create_all(bind=engine)
+    _run_migrations(bind=engine)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+def test_migration_adds_split_dosage_columns(legacy_engine):
+    with legacy_engine.connect() as conn:
+        cols = {c["name"] for c in inspect(conn).get_columns("medications")}
+    assert "dosage_quantity" in cols
+    assert "dosage_unit" in cols
+
+
+def test_migration_drops_obsolete_dosage_column(legacy_engine):
+    """The old NOT NULL ``dosage`` column must go — otherwise new medication
+    saves fail with a NOT NULL constraint error (issue #30)."""
+    with legacy_engine.connect() as conn:
+        cols = {c["name"] for c in inspect(conn).get_columns("medications")}
+    assert "dosage" not in cols
+
+
+def test_migration_parses_existing_dosage_values(legacy_engine):
+    with legacy_engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT medication_name, dosage_quantity, dosage_unit "
+                "FROM medications ORDER BY id"
+            )
+        ).fetchall()
+    assert rows[0] == ("Tylenol", 2.5, "mL")
+    assert rows[1] == ("Vitamin D", 400.0, "unit(s)")
+
+
+def test_migration_seeds_saved_medications(legacy_engine):
+    """Previously-logged medication names must appear in the autocomplete
+    source (issue #30, part 1)."""
+    with legacy_engine.connect() as conn:
+        names = [
+            r[0]
+            for r in conn.execute(text("SELECT name FROM saved_medications ORDER BY id")).fetchall()
+        ]
+    # "tylenol" should be deduped against "Tylenol" (first casing wins)
+    assert names == ["Tylenol", "Vitamin D"]
+
+
+def test_new_medication_insert_works_after_migration(legacy_engine):
+    """After the migration, a fresh ORM-style INSERT (which never supplies the
+    old ``dosage`` column) must succeed."""
+    with legacy_engine.connect() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO medications "
+                "(timestamp, medication_name, dosage_quantity, dosage_unit, notes, created_at) "
+                "VALUES (:ts, :name, :qty, :unit, :notes, :created_at)"
+            ),
+            {
+                "ts": "2026-04-24 00:00:00",
+                "name": "Advil",
+                "qty": 1.0,
+                "unit": "mL",
+                "notes": None,
+                "created_at": "2026-04-24 00:00:00",
+            },
+        )
+        conn.commit()
+        count = conn.execute(
+            text("SELECT COUNT(*) FROM medications WHERE medication_name = 'Advil'")
+        ).scalar()
+    assert count == 1
+
+
+def test_migration_is_idempotent(legacy_engine):
+    """Running migrations a second time must be a no-op and must not wipe
+    previously-seeded saved_medications."""
+    _run_migrations(bind=legacy_engine)
+    with legacy_engine.connect() as conn:
+        cols = {c["name"] for c in inspect(conn).get_columns("medications")}
+        saved = conn.execute(text("SELECT COUNT(*) FROM saved_medications")).scalar()
+    assert "dosage" not in cols
+    assert "dosage_quantity" in cols
+    assert saved == 2


### PR DESCRIPTION
Two issues were combining to break the Health modal on databases that had
been migrated from the pre-#26 schema:

1. The medication dosage split migration added ``dosage_quantity`` /
   ``dosage_unit`` but left the old NOT NULL ``dosage`` column in place.
   ORM INSERTs never supply ``dosage``, so every new medication save
   failed with ``sqlite3.IntegrityError: NOT NULL constraint failed:
   medications.dosage``. The migration now drops ``dosage`` after the
   data is copied across.

2. The saved_medications seed used ``INSERT OR IGNORE`` without setting
   ``created_at``. That column is NOT NULL at the SQL level with only a
   Python-side default, so every seed row was silently ignored and the
   autocomplete dropdown never showed names from prior log entries. The
   seed now populates ``created_at`` explicitly.

Adds tests/test_migrations.py exercising the pre-#26 schema end-to-end.

https://claude.ai/code/session_01UYBx89QarZM42qR8iKcUeh