### PR TITLE
Disable submit buttons during API requests to prevent duplicate submissions

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -139,7 +139,10 @@ function closeModal(id) {
     document.getElementById(id).classList.add('hidden');
     // Reset forms inside the modal
     const forms = document.getElementById(id).querySelectorAll('form');
-    forms.forEach(f => f.reset());
+    forms.forEach(f => {
+        f.reset();
+        f.querySelectorAll('button[type="submit"]').forEach(btn => { btn.disabled = false; });
+    });
     // Clear selected buttons
     document.getElementById(id).querySelectorAll('.btn-option.selected').forEach(b => b.classList.remove('selected'));
     if (id === 'health-modal') {
@@ -396,6 +399,8 @@ async function endTimer() {
         totals[seg.side] += dur;
     }
 
+    const confirmBtn = document.getElementById('timer-confirm-btn');
+    confirmBtn.disabled = true;
     try {
         // Save one entry per breast used; link paired breasts with a shared session_id
         const activeSides = Object.entries(totals).filter(([, ms]) => ms >= 1000);
@@ -432,6 +437,7 @@ async function endTimer() {
         }
         loadDashboard();
     } catch (e) {
+        confirmBtn.disabled = false;
         showToast('Error saving feeding: ' + e.message);
     }
 }
@@ -803,12 +809,15 @@ function initForms() {
         const notes = document.getElementById('diaper-notes').value || undefined;
         const timestampInput = document.getElementById('diaper-timestamp').value;
         const timestamp = timestampInput ? new Date(timestampInput).toISOString() : undefined;
+        const submitBtn = e.target.querySelector('button[type="submit"]');
+        submitBtn.disabled = true;
         try {
             await api.post('/api/diapers', { type, notes, timestamp });
             closeModal('diaper-modal');
             showToast('Diaper change logged!');
             loadDashboard();
         } catch (err) {
+            submitBtn.disabled = false;
             showToast('Error: ' + err.message);
         }
     });
@@ -816,6 +825,7 @@ function initForms() {
     // Feeding form
     document.getElementById('feeding-form').addEventListener('submit', async (e) => {
         e.preventDefault();
+        const saveBtn = document.getElementById('feeding-save-btn');
         const useTimer = document.getElementById('start-timer').checked;
         const notes = document.getElementById('feeding-notes').value || undefined;
         const timestampInput = document.getElementById('feeding-timestamp').value;
@@ -830,6 +840,7 @@ function initForms() {
                 const oz = document.getElementById('feeding-bottle-oz-timer-input').value;
                 if (!oz) { showToast('Please enter ounces'); return; }
                 const bottleType = document.getElementById('feeding-bottle-type-timer-select').value;
+                saveBtn.disabled = true;
                 try {
                     await api.post('/api/feedings', {
                         feeding_type: 'bottle',
@@ -842,12 +853,13 @@ function initForms() {
                     showToast('Feeding logged!');
                     loadDashboard();
                 } catch (err) {
+                    saveBtn.disabled = false;
                     showToast('Error: ' + err.message);
                 }
                 return;
             }
 
-            // Breast: start timer
+            // Breast: start timer (no API call)
             startTimer(feedingType);
             closeModal('feeding-modal');
             showToast('Timer started!');
@@ -864,6 +876,7 @@ function initForms() {
             return;
         }
 
+        saveBtn.disabled = true;
         try {
             const promises = [];
             let notesAttached = false;
@@ -906,6 +919,7 @@ function initForms() {
             showToast('Feeding logged!');
             loadDashboard();
         } catch (err) {
+            saveBtn.disabled = false;
             showToast('Error: ' + err.message);
         }
     });
@@ -933,12 +947,15 @@ function initForms() {
             showToast('Please select a unit');
             return;
         }
+        const submitBtn = e.target.querySelector('button[type="submit"]');
+        submitBtn.disabled = true;
         try {
             await api.post('/api/medications', { medication_name: name, dosage_quantity, dosage_unit, notes, timestamp });
             closeModal('health-modal');
             showToast('Medication logged!');
             loadDashboard();
         } catch (err) {
+            submitBtn.disabled = false;
             showToast('Error: ' + err.message);
         }
     });
@@ -958,6 +975,8 @@ function initForms() {
             tempValue = (tempValue - 32) * 5 / 9;
         }
 
+        const submitBtn = e.target.querySelector('button[type="submit"]');
+        submitBtn.disabled = true;
         try {
             await api.post('/api/temperatures', {
                 temperature_celsius: Math.round(tempValue * 10) / 10,
@@ -969,6 +988,7 @@ function initForms() {
             showToast('Temperature logged!');
             loadDashboard();
         } catch (err) {
+            submitBtn.disabled = false;
             showToast('Error: ' + err.message);
         }
     });


### PR DESCRIPTION
## Summary
This PR adds button disabling logic across all form submissions to prevent users from accidentally submitting duplicate requests while an API call is in progress. Submit buttons are disabled when a request starts and re-enabled only if an error occurs.

## Key Changes
- **Modal form submissions**: Updated `closeModal()` to re-enable all submit buttons when modals are closed, ensuring buttons are reset for the next use
- **Diaper logging**: Disable submit button during API request, re-enable on error
- **Feeding logging**: Disable save button for both bottle and breast feeding submissions, with proper error handling to re-enable on failure
- **Timer confirmation**: Disable the timer confirm button when ending a timer session, re-enable only if an error occurs
- **Medication logging**: Disable submit button during API request, re-enable on error
- **Temperature logging**: Disable submit button during API request, re-enable on error

## Implementation Details
- Buttons remain disabled on successful submission since the page reloads via `loadDashboard()`
- Buttons are only re-enabled in catch blocks to allow users to retry failed submissions
- The `closeModal()` function ensures all submit buttons are reset when modals are reopened, maintaining a clean state for subsequent submissions

https://claude.ai/code/session_01NbiKBMev9LGaWmCSb6ZEBz