### PR TITLE
Reset timer confirm button disabled state on UI show

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -325,7 +325,9 @@ function showTimerUI() {
 
     // Reset end/confirm UI
     document.getElementById('timer-end-btn').classList.remove('hidden');
-    document.getElementById('timer-confirm-btn').classList.add('hidden');
+    const confirmBtn = document.getElementById('timer-confirm-btn');
+    confirmBtn.classList.add('hidden');
+    confirmBtn.disabled = false;
     document.getElementById('timer-cancel-btn').classList.add('hidden');
     document.getElementById('timer-discard-btn').classList.remove('hidden');
     document.getElementById('timer-discard-confirm-btn').classList.add('hidden');


### PR DESCRIPTION
## Summary
This change ensures the timer confirm button is properly reset to an enabled state when the timer UI is displayed, preventing it from remaining disabled from a previous interaction.

## Key Changes
- Refactored the confirm button DOM access to use a variable for better code clarity
- Added explicit reset of the confirm button's `disabled` property to `false` when showing the timer UI

## Implementation Details
The confirm button is now explicitly re-enabled whenever `showTimerUI()` is called. This prevents a scenario where the button could remain in a disabled state from a previous user interaction, ensuring consistent UI behavior across timer sessions.

https://claude.ai/code/session_01Y8Kzg4Bf54DvyvgfAkQh8S