### PR TITLE
Increase precision for bottle amount inputs

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1122,7 +1122,7 @@ function buildFeedingEditFields(data, secondaryData = null) {
         </div>
         <div class="form-group" id="edit-oz-group" ${isBottle ? '' : 'style="display:none"'}>
             <label for="edit-amount-oz">Amount (oz)</label>
-            <input type="number" id="edit-amount-oz" min="0.5" max="12" step="0.5" value="${data.amount_oz || ''}">
+            <input type="number" id="edit-amount-oz" min="0.01" max="12.00" step="0.01" value="${data.amount_oz || ''}">
         </div>
         <div class="form-group" id="edit-bottle-type-group" ${isBottle ? '' : 'style="display:none"'}>
             <label for="edit-bottle-type">Bottle Type</label>

--- a/templates/index.html
+++ b/templates/index.html
@@ -142,7 +142,7 @@
                     <div id="feeding-bottle-oz-timer" class="form-group hidden">
                         <label>Amount &amp; Type</label>
                         <div class="input-group">
-                            <input type="number" id="feeding-bottle-oz-timer-input" min="0.5" max="12" step="0.5" placeholder="oz">
+                            <input type="number" id="feeding-bottle-oz-timer-input" min="0.01" max="12.00" step="0.01" placeholder="oz">
                             <select id="feeding-bottle-type-timer-select">
                                 <option value="breastmilk">Breastmilk (default)</option>
                                 <option value="formula">Formula</option>
@@ -164,7 +164,7 @@
                     <div class="form-group">
                         <label>🍼 Bottle</label>
                         <div class="input-group">
-                            <input type="number" id="feeding-bottle-oz" min="0.5" max="12" step="0.5" placeholder="oz">
+                            <input type="number" id="feeding-bottle-oz" min="0.01" max="12.00" step="0.01" placeholder="oz">
                             <select id="feeding-bottle-type-manual-select">
                                 <option value="breastmilk">Breastmilk (default)</option>
                                 <option value="formula">Formula</option>


### PR DESCRIPTION
Increase precision for bottle amount inputs from 0.5 oz steps to 0.01 oz and lower min to 0.01 across the app. Updated edit-amount-oz in static/js/app.js and feeding-bottle-oz-timer-input and feeding-bottle-oz in templates/index.html so users can record smaller, more precise bottle volumes.

Fixes issue #39.