### PR TITLE
Add support for bottle feed units (oz/mL)

### DIFF
--- a/migrations/migrate_add_bottle_feed_unit.py
+++ b/migrations/migrate_add_bottle_feed_unit.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Migration: Add amount_unit column to feedings and backfill bottle sessions with 'oz'.
+Safe to run multiple times (idempotent).
+"""
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+
+def migrate():
+    """Run the migration. Return True on success, False on failure."""
+    db_path = os.environ.get("PUFFIN_DB_PATH")
+
+    if not db_path:
+        prod_path = Path("/data/puffin.db")
+        dev_path = Path(__file__).parent.parent / "puffin.db"
+        db_path = str(prod_path) if prod_path.exists() else str(dev_path)
+
+    db_path = Path(db_path)
+
+    if not db_path.exists():
+        print(f"  Database not found at {db_path}")
+        print("  No migration needed - database will be created with correct schema.")
+        return True
+
+    print(f"Checking database at {db_path}...")
+
+    conn = sqlite3.connect(db_path)
+    cursor = conn.cursor()
+
+    try:
+        cursor.execute("PRAGMA table_info(feedings)")
+        columns = [col[1] for col in cursor.fetchall()]
+
+        if not columns:
+            print("  feedings table not found")
+            print("  No migration needed - table will be created with correct schema.")
+            return True
+
+        if "session_id" not in columns:
+            cursor.execute("ALTER TABLE feedings ADD COLUMN session_id TEXT")
+            columns.append("session_id")
+        if "bottle_type" not in columns:
+            cursor.execute("ALTER TABLE feedings ADD COLUMN bottle_type TEXT")
+            columns.append("bottle_type")
+
+        has_amount_unit = "amount_unit" in columns
+        has_amount_oz = "amount_oz" in columns
+        has_amount = "amount" in columns
+
+        if has_amount_unit:
+            print("✓ Migration: feedings.amount_unit already exists (idempotent check)")
+        else:
+            print("  Adding feedings.amount_unit column...")
+            cursor.execute("ALTER TABLE feedings ADD COLUMN amount_unit TEXT")
+            print("✓ Migration: feedings.amount_unit added")
+
+        cursor.execute(
+            "UPDATE feedings SET amount_unit = 'oz' "
+            "WHERE feeding_type = 'bottle' AND amount_unit IS NULL"
+        )
+        updated = cursor.rowcount
+        print(f"✓ Migration: backfilled {updated} bottle session(s) with amount_unit = 'oz'")
+
+        if has_amount_oz and not has_amount:
+            print("  Renaming feedings.amount_oz to feedings.amount...")
+            cursor.execute("PRAGMA foreign_keys=off")
+            cursor.execute(
+                """
+                CREATE TABLE feedings_new (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    timestamp DATETIME NOT NULL,
+                    feeding_type TEXT NOT NULL,
+                    duration_minutes INTEGER,
+                    amount REAL,
+                    amount_unit TEXT,
+                    notes TEXT,
+                    session_id TEXT,
+                    bottle_type TEXT,
+                    created_at DATETIME
+                )
+                """
+            )
+            cursor.execute(
+                """
+                INSERT INTO feedings_new
+                    (id, timestamp, feeding_type, duration_minutes, amount,
+                     amount_unit, notes, session_id, bottle_type, created_at)
+                SELECT
+                    id, timestamp, feeding_type, duration_minutes, amount_oz,
+                    amount_unit, notes, session_id, bottle_type, created_at
+                FROM feedings
+                """
+            )
+            cursor.execute("DROP TABLE feedings")
+            cursor.execute("ALTER TABLE feedings_new RENAME TO feedings")
+            cursor.execute(
+                "CREATE INDEX IF NOT EXISTS idx_feeding_timestamp ON feedings (timestamp)"
+            )
+            cursor.execute("PRAGMA foreign_keys=on")
+            print("✓ Migration: feedings.amount_oz renamed to feedings.amount")
+        elif has_amount:
+            print("✓ Migration: feedings.amount already exists (idempotent check)")
+
+        conn.commit()
+        print("✓ Migration complete: bottle feed unit support added")
+        return True
+
+    except sqlite3.Error as e:
+        print(f"✗ Migration failed: {e}")
+        conn.rollback()
+        return False
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    success = migrate()
+    sys.exit(0 if success else 1)

--- a/migrations/run_migrations.py
+++ b/migrations/run_migrations.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Run all database migrations in order.
+This script runs all migration files in sequence. Each migration should be idempotent.
+Add new migrations by importing them here and adding to the MIGRATIONS list.
+"""
+
+import sys
+
+
+def run_migrations():
+    """Run all migrations in order."""
+    try:
+        from migrate_add_bottle_feed_unit import (
+            migrate as migrate_001_add_bottle_feed_unit,
+        )
+    except ImportError as e:
+        print(f"✗ Failed to import migrations: {e}")
+        return False
+
+    migrations = [
+        ("001_add_bottle_feed_unit", migrate_001_add_bottle_feed_unit),
+    ]
+
+    print("=" * 60)
+    print("Running Puffin database migrations...")
+    print("=" * 60)
+
+    success = True
+    for name, migration_func in migrations:
+        print(f"\n[{name}]")
+        try:
+            result = migration_func()
+            if result is False:
+                print(f"✗ Migration {name} failed")
+                success = False
+                break
+        except Exception as e:
+            print(f"✗ Migration {name} raised exception: {e}")
+            success = False
+            break
+
+    print("\n" + "=" * 60)
+    if success:
+        print("✓ All migrations completed successfully")
+    else:
+        print("✗ Migrations failed")
+    print("=" * 60)
+
+    return success
+
+
+if __name__ == "__main__":
+    success = run_migrations()
+    sys.exit(0 if success else 1)

--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -106,21 +106,34 @@ def diaper_stats(db: Session) -> dict[str, int]:
 # --- Feedings ---
 
 
+def _format_bottle_amount(amount: float | None, amount_unit: str | None) -> str:
+    if amount is None or amount_unit is None:
+        return ""
+    if amount_unit == "mL":
+        return f"{amount:.0f} mL"
+    return f"{amount:.2f} oz"
+
+
 def create_feeding(
     db: Session,
     timestamp: datetime | None,
     feeding_type: str,
     duration_minutes: int | None,
-    amount_oz: float | None,
+    amount: float | None,
+    amount_unit: str | None,
     notes: str | None,
     session_id: str | None = None,
     bottle_type: str | None = None,
 ) -> Feeding:
+    if feeding_type != "bottle":
+        amount = None
+        amount_unit = None
     obj = Feeding(
         timestamp=timestamp or datetime.now(UTC),
         feeding_type=feeding_type,
         duration_minutes=duration_minutes,
-        amount_oz=amount_oz,
+        amount=amount,
+        amount_unit=amount_unit,
         notes=notes,
         session_id=session_id,
         bottle_type=bottle_type,
@@ -155,8 +168,12 @@ def update_feeding(db: Session, feeding_id: int, **kwargs) -> Feeding | None:
     obj = db.get(Feeding, feeding_id)
     if not obj:
         return None
+    target_type = kwargs.get("feeding_type", obj.feeding_type)
+    if target_type in {"breast_left", "breast_right"}:
+        kwargs["amount"] = None
+        kwargs["amount_unit"] = None
     for k, v in kwargs.items():
-        if v is not None:
+        if v is not None or k in {"amount", "amount_unit"}:
             setattr(obj, k, v)
     db.commit()
     db.refresh(obj)
@@ -180,17 +197,13 @@ def _feeding_session_count(db: Session, start: datetime) -> int:
     individually by falling back to their row ``id``.
     """
     session_key = func.coalesce(Feeding.session_id, cast(Feeding.id, String))
-    stmt = select(func.count(func.distinct(session_key))).where(
-        Feeding.timestamp >= start
-    )
+    stmt = select(func.count(func.distinct(session_key))).where(Feeding.timestamp >= start)
     return db.execute(stmt).scalar() or 0
 
 
 def _count_range(db: Session, model, timestamp_col, start: datetime, end: datetime) -> int:
     stmt = (
-        select(func.count())
-        .select_from(model)
-        .where(timestamp_col >= start, timestamp_col < end)
+        select(func.count()).select_from(model).where(timestamp_col >= start, timestamp_col < end)
     )
     return db.execute(stmt).scalar() or 0
 
@@ -448,9 +461,9 @@ def get_activities(
         if f.session_id:
             session_groups.setdefault(f.session_id, []).append(f)
         else:
-            if f.amount_oz:
+            if f.amount is not None and f.amount_unit:
                 bottle_label = "Formula" if f.bottle_type == "formula" else "Breastmilk"
-                detail = f"{bottle_label} · {f.amount_oz} oz"
+                detail = f"{bottle_label} · {_format_bottle_amount(f.amount, f.amount_unit)}"
             elif f.duration_minutes:
                 detail = f"{f.duration_minutes} min"
             else:

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -42,7 +42,9 @@ def _parse_dosage(dosage: str) -> tuple[float, str]:
     if m:
         try:
             qty = round(float(m.group(1)), 2)
-            unit = _DOSAGE_UNIT_MAP.get(m.group(2), _DOSAGE_UNIT_MAP.get(m.group(2).lower(), "unit(s)"))
+            unit = _DOSAGE_UNIT_MAP.get(
+                m.group(2), _DOSAGE_UNIT_MAP.get(m.group(2).lower(), "unit(s)")
+            )
             return qty, unit
         except ValueError:
             pass
@@ -53,6 +55,7 @@ def _parse_dosage(dosage: str) -> tuple[float, str]:
         except ValueError:
             pass
     return 0.0, "unit(s)"
+
 
 DB_PATH = os.environ.get(
     "PUFFIN_DB_PATH",
@@ -93,8 +96,54 @@ def _run_migrations(bind=None) -> None:
         if "session_id" not in existing_cols:
             conn.execute(text("ALTER TABLE feedings ADD COLUMN session_id TEXT"))
             conn.commit()
+            existing_cols.add("session_id")
         if "bottle_type" not in existing_cols:
             conn.execute(text("ALTER TABLE feedings ADD COLUMN bottle_type TEXT"))
+            conn.commit()
+            existing_cols.add("bottle_type")
+        if "amount_unit" not in existing_cols:
+            conn.execute(text("ALTER TABLE feedings ADD COLUMN amount_unit TEXT"))
+            conn.commit()
+            existing_cols.add("amount_unit")
+        conn.execute(
+            text(
+                "UPDATE feedings SET amount_unit = 'oz' "
+                "WHERE feeding_type = 'bottle' AND amount_unit IS NULL"
+            )
+        )
+        conn.commit()
+        if "amount_oz" in existing_cols and "amount" not in existing_cols:
+            conn.execute(text("PRAGMA foreign_keys=off"))
+            conn.execute(
+                text(
+                    "CREATE TABLE feedings_new ("
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                    "timestamp DATETIME NOT NULL, "
+                    "feeding_type VARCHAR NOT NULL, "
+                    "duration_minutes INTEGER, "
+                    "amount FLOAT, "
+                    "amount_unit VARCHAR, "
+                    "notes TEXT, "
+                    "session_id VARCHAR, "
+                    "bottle_type VARCHAR, "
+                    "created_at DATETIME)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO feedings_new "
+                    "(id, timestamp, feeding_type, duration_minutes, amount, amount_unit, "
+                    "notes, session_id, bottle_type, created_at) "
+                    "SELECT id, timestamp, feeding_type, duration_minutes, amount_oz, amount_unit, "
+                    "notes, session_id, bottle_type, created_at FROM feedings"
+                )
+            )
+            conn.execute(text("DROP TABLE feedings"))
+            conn.execute(text("ALTER TABLE feedings_new RENAME TO feedings"))
+            conn.execute(
+                text("CREATE INDEX IF NOT EXISTS idx_feeding_timestamp ON feedings (timestamp)")
+            )
+            conn.execute(text("PRAGMA foreign_keys=on"))
             conn.commit()
 
         insp = inspect(conn)
@@ -106,7 +155,9 @@ def _run_migrations(bind=None) -> None:
                 text("ALTER TABLE medications ADD COLUMN dosage_quantity REAL NOT NULL DEFAULT 0.0")
             )
             conn.execute(
-                text("ALTER TABLE medications ADD COLUMN dosage_unit TEXT NOT NULL DEFAULT 'unit(s)'")
+                text(
+                    "ALTER TABLE medications ADD COLUMN dosage_unit TEXT NOT NULL DEFAULT 'unit(s)'"
+                )
             )
             conn.commit()
             # Attempt to migrate existing free-text dosage values
@@ -115,7 +166,8 @@ def _run_migrations(bind=None) -> None:
                 qty, unit = _parse_dosage(dosage_text or "")
                 conn.execute(
                     text(
-                        "UPDATE medications SET dosage_quantity = :qty, dosage_unit = :unit WHERE id = :id"
+                        "UPDATE medications SET dosage_quantity = :qty, dosage_unit = :unit "
+                        "WHERE id = :id"
                     ),
                     {"qty": qty, "unit": unit, "id": row_id},
                 )

--- a/src/puffin/models.py
+++ b/src/puffin/models.py
@@ -51,7 +51,8 @@ class Feeding(Base):
         String, nullable=False
     )  # breast_left, breast_right, bottle
     duration_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    amount_oz: Mapped[float | None] = mapped_column(Float, nullable=True)
+    amount: Mapped[float | None] = mapped_column(Float, nullable=True)
+    amount_unit: Mapped[str | None] = mapped_column(String, nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     session_id: Mapped[str | None] = mapped_column(String, nullable=True)
     bottle_type: Mapped[str | None] = mapped_column(String, nullable=True)  # breastmilk, formula

--- a/src/puffin/routers/dashboard.py
+++ b/src/puffin/routers/dashboard.py
@@ -16,6 +16,14 @@ router = APIRouter(prefix="/api", tags=["dashboard"])
 _PDF_MAX_CELL_LENGTH = 40  # max characters per cell before truncation
 
 
+def _format_bottle_amount(amount: float | None, amount_unit: str | None) -> str:
+    if amount is None or amount_unit is None:
+        return ""
+    if amount_unit == "mL":
+        return f"{amount:.0f} mL"
+    return f"{amount:.2f} oz"
+
+
 @router.get("/dashboard", response_model=DashboardSummary)
 def get_dashboard(
     date: str | None = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"),
@@ -72,8 +80,7 @@ def export_data(
             def header(self):
                 self.set_font("Helvetica", "B", 16)
                 self.cell(
-                    0, 10, "Puffin Baby Tracker Report",
-                    align="C", new_x="LMARGIN", new_y="NEXT"
+                    0, 10, "Puffin Baby Tracker Report", align="C", new_x="LMARGIN", new_y="NEXT"
                 )
                 self.set_font("Helvetica", "", 9)
                 report_range = _build_date_range_label(start_date, end_date)
@@ -89,45 +96,65 @@ def export_data(
         pdf.set_auto_page_break(auto=True, margin=15)
         pdf.add_page()
 
-        _pdf_section(pdf, "Diaper Changes", ["Time", "Type", "Notes"], [
+        _pdf_section(
+            pdf,
+            "Diaper Changes",
+            ["Time", "Type", "Notes"],
             [
-                _fmt_ts(d.timestamp),
-                str(d.type),
-                d.notes or "",
-            ]
-            for d in diapers
-        ])
+                [
+                    _fmt_ts(d.timestamp),
+                    str(d.type),
+                    d.notes or "",
+                ]
+                for d in diapers
+            ],
+        )
 
-        _pdf_section(pdf, "Feedings", ["Time", "Type", "Duration (min)", "Amount (oz)", "Notes"], [
+        _pdf_section(
+            pdf,
+            "Feedings",
+            ["Time", "Type", "Duration (min)", "Amount", "Notes"],
             [
-                _fmt_ts(f.timestamp),
-                str(f.feeding_type),
-                str(f.duration_minutes) if f.duration_minutes is not None else "",
-                str(f.amount_oz) if f.amount_oz is not None else "",
-                f.notes or "",
-            ]
-            for f in feedings
-        ])
+                [
+                    _fmt_ts(f.timestamp),
+                    str(f.feeding_type),
+                    str(f.duration_minutes) if f.duration_minutes is not None else "",
+                    _format_bottle_amount(f.amount, f.amount_unit),
+                    f.notes or "",
+                ]
+                for f in feedings
+            ],
+        )
 
-        _pdf_section(pdf, "Medications", ["Time", "Medication", "Dosage", "Notes"], [
+        _pdf_section(
+            pdf,
+            "Medications",
+            ["Time", "Medication", "Dosage", "Notes"],
             [
-                _fmt_ts(m.timestamp),
-                m.medication_name,
-                f"{m.dosage_quantity:.2f} {m.dosage_unit}",
-                m.notes or "",
-            ]
-            for m in medications
-        ])
+                [
+                    _fmt_ts(m.timestamp),
+                    m.medication_name,
+                    f"{m.dosage_quantity:.2f} {m.dosage_unit}",
+                    m.notes or "",
+                ]
+                for m in medications
+            ],
+        )
 
-        _pdf_section(pdf, "Temperature Readings", ["Time", "Temp (°C)", "Location", "Notes"], [
+        _pdf_section(
+            pdf,
+            "Temperature Readings",
+            ["Time", "Temp (°C)", "Location", "Notes"],
             [
-                _fmt_ts(t.timestamp),
-                str(t.temperature_celsius),
-                str(t.location) if t.location else "",
-                t.notes or "",
-            ]
-            for t in temperatures
-        ])
+                [
+                    _fmt_ts(t.timestamp),
+                    str(t.temperature_celsius),
+                    str(t.location) if t.location else "",
+                    t.notes or "",
+                ]
+                for t in temperatures
+            ],
+        )
 
         pdf_bytes = pdf.output()
         return StreamingResponse(
@@ -148,7 +175,16 @@ def export_data(
     writer.writerow([])
     writer.writerow(["--- Feedings ---"])
     writer.writerow(
-        ["id", "timestamp", "feeding_type", "duration_minutes", "amount_oz", "notes", "created_at"]
+        [
+            "id",
+            "timestamp",
+            "feeding_type",
+            "duration_minutes",
+            "amount",
+            "amount_unit",
+            "notes",
+            "created_at",
+        ]
     )
     for f in feedings:
         writer.writerow(
@@ -157,7 +193,8 @@ def export_data(
                 f.timestamp,
                 f.feeding_type,
                 f.duration_minutes,
-                f.amount_oz,
+                f.amount,
+                f.amount_unit,
                 f.notes,
                 f.created_at,
             ]
@@ -165,9 +202,29 @@ def export_data(
 
     writer.writerow([])
     writer.writerow(["--- Medications ---"])
-    writer.writerow(["id", "timestamp", "medication_name", "dosage_quantity", "dosage_unit", "notes", "created_at"])
+    writer.writerow(
+        [
+            "id",
+            "timestamp",
+            "medication_name",
+            "dosage_quantity",
+            "dosage_unit",
+            "notes",
+            "created_at",
+        ]
+    )
     for m in medications:
-        writer.writerow([m.id, m.timestamp, m.medication_name, m.dosage_quantity, m.dosage_unit, m.notes, m.created_at])
+        writer.writerow(
+            [
+                m.id,
+                m.timestamp,
+                m.medication_name,
+                m.dosage_quantity,
+                m.dosage_unit,
+                m.notes,
+                m.created_at,
+            ]
+        )
 
     writer.writerow([])
     writer.writerow(["--- Temperature Readings ---"])

--- a/src/puffin/routers/feedings.py
+++ b/src/puffin/routers/feedings.py
@@ -17,7 +17,8 @@ def create_feeding(data: FeedingCreate, db: Session = Depends(get_db)):
         timestamp=data.timestamp,
         feeding_type=data.feeding_type.value,
         duration_minutes=data.duration_minutes,
-        amount_oz=data.amount_oz,
+        amount=data.amount,
+        amount_unit=data.amount_unit.value if data.amount_unit else None,
         notes=data.notes,
         session_id=data.session_id,
         bottle_type=data.bottle_type.value if data.bottle_type else None,
@@ -52,6 +53,15 @@ def get_feeding(feeding_id: int, db: Session = Depends(get_db)):
 
 @router.put("/{feeding_id}", response_model=FeedingResponse)
 def update_feeding(feeding_id: int, data: FeedingUpdate, db: Session = Depends(get_db)):
+    existing = crud.get_feeding(db, feeding_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Feeding not found")
+    target_type = data.feeding_type.value if data.feeding_type else existing.feeding_type
+    if target_type == "bottle" and (data.amount is None) != (data.amount_unit is None):
+        raise HTTPException(
+            status_code=422,
+            detail="Bottle feeds require amount and amount_unit together",
+        )
     updates = {}
     if data.timestamp is not None:
         updates["timestamp"] = data.timestamp
@@ -59,16 +69,15 @@ def update_feeding(feeding_id: int, data: FeedingUpdate, db: Session = Depends(g
         updates["feeding_type"] = data.feeding_type.value
     if data.duration_minutes is not None:
         updates["duration_minutes"] = data.duration_minutes
-    if data.amount_oz is not None:
-        updates["amount_oz"] = data.amount_oz
+    if data.amount is not None:
+        updates["amount"] = data.amount
+    if data.amount_unit is not None:
+        updates["amount_unit"] = data.amount_unit.value
     if data.notes is not None:
         updates["notes"] = data.notes
     if data.bottle_type is not None:
         updates["bottle_type"] = data.bottle_type.value
-    obj = crud.update_feeding(db, feeding_id, **updates)
-    if not obj:
-        raise HTTPException(status_code=404, detail="Feeding not found")
-    return obj
+    return crud.update_feeding(db, feeding_id, **updates)
 
 
 @router.delete("/{feeding_id}", status_code=204)

--- a/src/puffin/schemas.py
+++ b/src/puffin/schemas.py
@@ -1,8 +1,9 @@
-from decimal import Decimal
 from datetime import datetime
+from decimal import Decimal
 from enum import StrEnum
+from typing import Self
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 # --- Enums ---
 
@@ -25,6 +26,11 @@ class BottleType(StrEnum):
     formula = "formula"
 
 
+class BottleUnit(StrEnum):
+    oz = "oz"
+    ml = "mL"
+
+
 class TemperatureLocation(StrEnum):
     rectal = "rectal"
     oral = "oral"
@@ -33,7 +39,7 @@ class TemperatureLocation(StrEnum):
 
 
 class DosageUnit(StrEnum):
-    mL = "mL"
+    ml = "mL"
     tsp = "tsp(s)"
     tbsp = "tbsp(s)"
     drop = "drop(s)"
@@ -74,19 +80,41 @@ class FeedingCreate(BaseModel):
     timestamp: datetime | None = None
     feeding_type: FeedingType
     duration_minutes: int | None = None
-    amount_oz: float | None = None
+    amount: float | None = None
+    amount_unit: BottleUnit | None = None
     notes: str | None = None
     session_id: str | None = None
     bottle_type: BottleType | None = None
+
+    @model_validator(mode="after")
+    def validate_bottle_amount(self) -> Self:
+        if self.feeding_type == FeedingType.bottle:
+            if (self.amount is None) != (self.amount_unit is None):
+                raise ValueError("Bottle feeds require amount and amount_unit together")
+        else:
+            self.amount = None
+            self.amount_unit = None
+        return self
 
 
 class FeedingUpdate(BaseModel):
     timestamp: datetime | None = None
     feeding_type: FeedingType | None = None
     duration_minutes: int | None = None
-    amount_oz: float | None = None
+    amount: float | None = None
+    amount_unit: BottleUnit | None = None
     notes: str | None = None
     bottle_type: BottleType | None = None
+
+    @model_validator(mode="after")
+    def validate_bottle_amount(self) -> Self:
+        if self.feeding_type == FeedingType.bottle:
+            if (self.amount is None) != (self.amount_unit is None):
+                raise ValueError("Bottle feeds require amount and amount_unit together")
+        elif self.feeding_type in {FeedingType.breast_left, FeedingType.breast_right}:
+            self.amount = None
+            self.amount_unit = None
+        return self
 
 
 class FeedingResponse(BaseModel):
@@ -96,7 +124,8 @@ class FeedingResponse(BaseModel):
     timestamp: datetime
     feeding_type: FeedingType
     duration_minutes: int | None
-    amount_oz: float | None
+    amount: float | None
+    amount_unit: BottleUnit | None
     notes: str | None
     session_id: str | None
     bottle_type: BottleType | None

--- a/src/puffin/seed.py
+++ b/src/puffin/seed.py
@@ -77,7 +77,8 @@ def generate_feedings(day_offset: int, base_date: datetime, now: datetime) -> li
                 Feeding(
                     timestamp=current_time,
                     feeding_type="bottle",
-                    amount_oz=round(random.uniform(1.0, 4.0), 1),
+                    amount=round(random.uniform(1.0, 4.0), 1),
+                    amount_unit="oz",
                     notes=random.choice(FEEDING_NOTES),
                     created_at=current_time,
                 )

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -46,12 +46,41 @@ const BREAST_RIGHT_KEY = 'puffin-breast-right-name';
 const DEFAULT_LEFT_NAME = 'Left';
 const DEFAULT_RIGHT_NAME = 'Right';
 
-/* ===== Bottle Type ===== */
+/* ===== Bottle Defaults ===== */
 const BOTTLE_TYPE_KEY = 'puffin-bottle-type-default';
+const BOTTLE_UNIT_KEY = 'defaultBottleUnit';
 const DEFAULT_BOTTLE_TYPE = 'breastmilk';
+const DEFAULT_BOTTLE_UNIT = 'oz';
 
 function getDefaultBottleType() {
     return localStorage.getItem(BOTTLE_TYPE_KEY) || DEFAULT_BOTTLE_TYPE;
+}
+
+function getDefaultBottleUnit() {
+    const unit = localStorage.getItem(BOTTLE_UNIT_KEY) || DEFAULT_BOTTLE_UNIT;
+    return unit === 'mL' ? 'mL' : 'oz';
+}
+
+function validateBottleAmountUnit(amount, unit) {
+    if (unit === 'mL' && !Number.isInteger(Number(amount))) {
+        showToast('mL amounts must be whole numbers');
+        return false;
+    }
+    return true;
+}
+
+function updateBottleUnitLabels() {
+    const defaultUnit = getDefaultBottleUnit();
+    const selects = [
+        document.getElementById('feeding-bottle-unit-timer-select'),
+        document.getElementById('feeding-bottle-unit-manual-select'),
+    ];
+    for (const sel of selects) {
+        if (!sel) continue;
+        sel.querySelector('option[value="oz"]').textContent = 'oz' + (defaultUnit === 'oz' ? ' (default)' : '');
+        sel.querySelector('option[value="mL"]').textContent = 'mL' + (defaultUnit === 'mL' ? ' (default)' : '');
+        sel.value = defaultUnit;
+    }
 }
 
 function updateBottleTypeLabels() {
@@ -125,6 +154,7 @@ function openModal(id) {
         loadLastBreastFeeding();
         loadNoteSuggestions('/api/feedings', 'feeding-note-suggestions', 'feeding-notes');
         updateBottleTypeLabels();
+        updateBottleUnitLabels();
     } else if (id === 'diaper-modal') {
         loadNoteSuggestions('/api/diapers', 'diaper-note-suggestions', 'diaper-notes');
     } else if (id === 'health-modal') {
@@ -152,7 +182,7 @@ function closeModal(id) {
     if (id === 'feeding-modal') {
         document.getElementById('feeding-timer-mode').classList.remove('hidden');
         document.getElementById('feeding-manual-mode').classList.add('hidden');
-        document.getElementById('feeding-bottle-oz-timer').classList.add('hidden');
+        document.getElementById('feeding-bottle-timer').classList.add('hidden');
         const timerRow = document.getElementById('timer-toggle-row');
         if (timerRow) timerRow.classList.remove('hidden');
         document.getElementById('feeding-save-btn').disabled = true;
@@ -574,8 +604,8 @@ function initFeedingForm() {
     const timerToggleRow = document.getElementById('timer-toggle-row');
     const timerMode = document.getElementById('feeding-timer-mode');
     const manualMode = document.getElementById('feeding-manual-mode');
-    const bottleOzTimerGroup = document.getElementById('feeding-bottle-oz-timer');
-    const bottleOzTimerInput = document.getElementById('feeding-bottle-oz-timer-input');
+    const bottleOzTimerGroup = document.getElementById('feeding-bottle-timer');
+    const bottleOzTimerInput = document.getElementById('feeding-bottle-timer-input');
     const saveBtn = document.getElementById('feeding-save-btn');
 
     function updateMode() {
@@ -600,14 +630,14 @@ function initFeedingForm() {
             return;
         }
         if (ft === 'bottle') {
-            // Bottle: hide timer toggle, show ounces, require a value, set button to Save
+            // Bottle: hide timer toggle, show amount, require a value, set button to Save
             if (timerToggleRow) timerToggleRow.classList.add('hidden');
             bottleOzTimerGroup.classList.remove('hidden');
             saveBtn.textContent = 'Save';
-            const hasOz = !!bottleOzTimerInput.value;
-            saveBtn.disabled = !hasOz;
+            const hasAmount = !!bottleOzTimerInput.value;
+            saveBtn.disabled = !hasAmount;
         } else {
-            // Breast: show timer toggle, hide ounces, enable Start
+            // Breast: show timer toggle, hide amount, enable Start
             if (timerToggleRow) timerToggleRow.classList.remove('hidden');
             bottleOzTimerGroup.classList.add('hidden');
             saveBtn.textContent = 'Start';
@@ -618,7 +648,7 @@ function initFeedingForm() {
     function updateManualBtnState() {
         const l = document.getElementById('feeding-left-duration').value;
         const r = document.getElementById('feeding-right-duration').value;
-        const b = document.getElementById('feeding-bottle-oz').value;
+        const b = document.getElementById('feeding-bottle').value;
         saveBtn.disabled = !(l || r || b);
     }
 
@@ -633,11 +663,10 @@ function initFeedingForm() {
         }
     });
 
-    // Recompute when ounces entered in timer mode
     bottleOzTimerInput.addEventListener('input', updateTimerBtnState);
 
     // Manual mode: enable save when any field is entered
-    ['feeding-left-duration', 'feeding-right-duration', 'feeding-bottle-oz'].forEach(id => {
+    ['feeding-left-duration', 'feeding-right-duration', 'feeding-bottle'].forEach(id => {
         document.getElementById(id).addEventListener('input', updateManualBtnState);
     });
 
@@ -839,14 +868,17 @@ function initForms() {
             if (!feedingType) { showToast('Please select a feeding type'); return; }
 
             if (feedingType === 'bottle') {
-                const oz = document.getElementById('feeding-bottle-oz-timer-input').value;
-                if (!oz) { showToast('Please enter ounces'); return; }
+                const amount = document.getElementById('feeding-bottle-timer-input').value;
+                const amountUnit = document.getElementById('feeding-bottle-unit-timer-select').value;
+                if (!amount) { showToast(`Please enter ${amountUnit}`); return; }
+                if (!validateBottleAmountUnit(amount, amountUnit)) return;
                 const bottleType = document.getElementById('feeding-bottle-type-timer-select').value;
                 saveBtn.disabled = true;
                 try {
                     await api.post('/api/feedings', {
                         feeding_type: 'bottle',
-                        amount_oz: parseFloat(oz),
+                        amount: parseFloat(amount),
+                        amount_unit: amountUnit,
                         bottle_type: bottleType,
                         notes,
                         timestamp,
@@ -871,12 +903,14 @@ function initForms() {
         // Manual mode: create entries for each non-empty field
         const leftDur = document.getElementById('feeding-left-duration').value;
         const rightDur = document.getElementById('feeding-right-duration').value;
-        const bottleOz = document.getElementById('feeding-bottle-oz').value;
+        const bottleAmount = document.getElementById('feeding-bottle').value;
+        const bottleUnit = document.getElementById('feeding-bottle-unit-manual-select').value;
 
-        if (!leftDur && !rightDur && !bottleOz) {
+        if (!leftDur && !rightDur && !bottleAmount) {
             showToast('Please enter at least one value');
             return;
         }
+        if (bottleAmount && !validateBottleAmountUnit(bottleAmount, bottleUnit)) return;
 
         saveBtn.disabled = true;
         try {
@@ -906,11 +940,12 @@ function initForms() {
                 promises.push(api.post('/api/feedings', body));
                 notesAttached = true;
             }
-            if (bottleOz) {
+            if (bottleAmount) {
                 const bottleType = document.getElementById('feeding-bottle-type-manual-select').value;
                 promises.push(api.post('/api/feedings', {
                     feeding_type: 'bottle',
-                    amount_oz: parseFloat(bottleOz),
+                    amount: parseFloat(bottleAmount),
+                    amount_unit: bottleUnit,
                     bottle_type: bottleType,
                     notes: notesAttached ? undefined : notes,
                     timestamp,
@@ -1106,6 +1141,7 @@ function buildFeedingEditFields(data, secondaryData = null) {
     const isBottle = data.feeding_type === 'bottle';
     const names = getBreastNames();
     const bottleTypeVal = data.bottle_type || 'breastmilk';
+    const bottleUnitVal = data.amount_unit || getDefaultBottleUnit();
     return `
         <div class="form-group">
             <label>Type</label>
@@ -1121,8 +1157,14 @@ function buildFeedingEditFields(data, secondaryData = null) {
             <input type="number" id="edit-duration" min="1" max="120" value="${data.duration_minutes || ''}">
         </div>
         <div class="form-group" id="edit-oz-group" ${isBottle ? '' : 'style="display:none"'}>
-            <label for="edit-amount-oz">Amount (oz)</label>
-            <input type="number" id="edit-amount-oz" min="0.01" max="12.00" step="0.01" value="${data.amount_oz || ''}">
+            <label for="edit-amount">Amount</label>
+            <div class="input-group">
+                <input type="number" id="edit-amount" min="0.01" step="0.01" value="${data.amount || ''}">
+                <select id="edit-amount-unit">
+                    <option value="oz" ${bottleUnitVal === 'oz' ? 'selected' : ''}>oz</option>
+                    <option value="mL" ${bottleUnitVal === 'mL' ? 'selected' : ''}>mL</option>
+                </select>
+            </div>
         </div>
         <div class="form-group" id="edit-bottle-type-group" ${isBottle ? '' : 'style="display:none"'}>
             <label for="edit-bottle-type">Bottle Type</label>
@@ -1224,8 +1266,13 @@ function buildEditBody(type) {
         case 'feeding': {
             body.feeding_type = document.getElementById('edit-feeding-type').value;
             if (body.feeding_type === 'bottle') {
-                const oz = document.getElementById('edit-amount-oz').value;
-                if (oz) body.amount_oz = parseFloat(oz);
+                const amount = document.getElementById('edit-amount').value;
+                const amountUnit = document.getElementById('edit-amount-unit').value;
+                if (amount) {
+                    if (!validateBottleAmountUnit(amount, amountUnit)) return null;
+                    body.amount = parseFloat(amount);
+                    body.amount_unit = amountUnit;
+                }
                 const btEl = document.getElementById('edit-bottle-type');
                 if (btEl) body.bottle_type = btEl.value;
             } else {
@@ -1261,7 +1308,7 @@ function initEditOptionButtons() {
             btn.classList.add('selected');
             document.getElementById(field).value = value;
 
-            // Toggle duration vs ounces/bottle-type for feeding edits
+            // Toggle duration vs amount/bottle-type for feeding edits
             if (field === 'edit-feeding-type') {
                 const durGroup = document.getElementById('edit-duration-group');
                 const ozGroup = document.getElementById('edit-oz-group');
@@ -1310,7 +1357,9 @@ function initEditForm() {
                     api.put(`/api/feedings/${rightIdEl.value}`, rightBody),
                 ]);
             } else {
-                await api.put(endpoints[type], buildEditBody(type));
+                const body = buildEditBody(type);
+                if (!body) return;
+                await api.put(endpoints[type], body);
             }
             closeModal('edit-modal');
             showToast('Updated!');
@@ -1532,6 +1581,8 @@ function initSettings() {
         document.getElementById('settings-left-name').value = names.left;
         document.getElementById('settings-right-name').value = names.right;
         document.getElementById('settings-bottle-type').value = getDefaultBottleType();
+        document.getElementById('settings-bottle-unit').value = getDefaultBottleUnit();
+        updateBottleUnitLabels();
         openModal('settings-modal');
     });
 
@@ -1540,12 +1591,15 @@ function initSettings() {
         const leftName = document.getElementById('settings-left-name').value.trim() || DEFAULT_LEFT_NAME;
         const rightName = document.getElementById('settings-right-name').value.trim() || DEFAULT_RIGHT_NAME;
         const bottleType = document.getElementById('settings-bottle-type').value;
+        const bottleUnit = document.getElementById('settings-bottle-unit').value;
         localStorage.setItem(BREAST_LEFT_KEY, leftName);
         localStorage.setItem(BREAST_RIGHT_KEY, rightName);
         localStorage.setItem(BOTTLE_TYPE_KEY, bottleType);
+        localStorage.setItem(BOTTLE_UNIT_KEY, bottleUnit);
         closeModal('settings-modal');
         updateBreastLabels();
         updateBottleTypeLabels();
+        updateBottleUnitLabels();
         if (getTimerState()) showTimerUI();
         showToast('Settings saved!');
     });
@@ -1587,6 +1641,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initExport();
     updateBreastLabels();
     updateBottleTypeLabels();
+    updateBottleUnitLabels();
     loadDashboard();
 
     // Theme toggle

--- a/templates/index.html
+++ b/templates/index.html
@@ -139,10 +139,14 @@
                         </div>
                         <input type="hidden" id="feeding-type">
                     </div>
-                    <div id="feeding-bottle-oz-timer" class="form-group hidden">
-                        <label>Amount &amp; Type</label>
+                    <div id="feeding-bottle-timer" class="form-group hidden">
+                        <label>Amount</label>
                         <div class="input-group">
-                            <input type="number" id="feeding-bottle-oz-timer-input" min="0.01" max="12.00" step="0.01" placeholder="oz">
+                            <input type="number" id="feeding-bottle-timer-input" min="0.01" step="0.01">
+                            <select id="feeding-bottle-unit-timer-select">
+                                <option value="oz">oz</option>
+                                <option value="mL">mL</option>
+                            </select>
                             <select id="feeding-bottle-type-timer-select">
                                 <option value="breastmilk">Breastmilk (default)</option>
                                 <option value="formula">Formula</option>
@@ -164,7 +168,11 @@
                     <div class="form-group">
                         <label>🍼 Bottle</label>
                         <div class="input-group">
-                            <input type="number" id="feeding-bottle-oz" min="0.01" max="12.00" step="0.01" placeholder="oz">
+                            <input type="number" id="feeding-bottle" min="0.01" step="0.01">
+                            <select id="feeding-bottle-unit-manual-select">
+                                <option value="oz">oz</option>
+                                <option value="mL">mL</option>
+                            </select>
                             <select id="feeding-bottle-type-manual-select">
                                 <option value="breastmilk">Breastmilk (default)</option>
                                 <option value="formula">Formula</option>
@@ -322,6 +330,13 @@
                     <select id="settings-bottle-type">
                         <option value="breastmilk">Breastmilk</option>
                         <option value="formula">Formula</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="settings-bottle-unit">Default bottle unit</label>
+                    <select id="settings-bottle-unit">
+                        <option value="oz">oz</option>
+                        <option value="mL">mL</option>
                     </select>
                 </div>
                 <div class="form-actions">

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -52,6 +52,41 @@ def test_list_activities_paired_session_merged(client):
     assert "Right" in feeding_activities[0]["detail"]
 
 
+def test_list_activities_formats_bottle_oz(client):
+    from datetime import UTC, datetime
+
+    client.post(
+        "/api/feedings",
+        json={
+            "feeding_type": "bottle",
+            "amount": 3.5,
+            "amount_unit": "oz",
+            "bottle_type": "formula",
+        },
+    )
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    resp = client.get(f"/api/activities?date={today}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["detail"] == "Formula · 3.50 oz"
+
+
+def test_list_activities_formats_bottle_ml(client):
+    from datetime import UTC, datetime
+
+    client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 100, "amount_unit": "mL"},
+    )
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    resp = client.get(f"/api/activities?date={today}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["detail"] == "Breastmilk · 100 mL"
+
+
 def test_list_activities_empty(client):
     """No activities for a date far in the past."""
     resp = client.get("/api/activities?date=2000-01-01")

--- a/tests/test_feedings.py
+++ b/tests/test_feedings.py
@@ -26,13 +26,52 @@ def test_create_bottle_feeding(client):
 def test_create_bottle_feeding_with_oz(client):
     resp = client.post(
         "/api/feedings",
-        json={"feeding_type": "bottle", "amount_oz": 3.5},
+        json={"feeding_type": "bottle", "amount": 3.5, "amount_unit": "oz"},
     )
     assert resp.status_code == 201
     data = resp.json()
     assert data["feeding_type"] == "bottle"
-    assert data["amount_oz"] == 3.5
+    assert data["amount"] == 3.5
+    assert data["amount_unit"] == "oz"
     assert data["duration_minutes"] is None
+
+
+def test_create_bottle_feeding_with_ml(client):
+    resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 120, "amount_unit": "mL"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["amount"] == 120
+    assert data["amount_unit"] == "mL"
+
+
+def test_create_bottle_feeding_amount_requires_unit(client):
+    resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 3.5},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_bottle_feeding_unit_requires_amount(client):
+    resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount_unit": "oz"},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_breast_feeding_normalizes_amount_unit(client):
+    resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "breast_left", "amount": 3.5, "amount_unit": "oz"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["amount"] is None
+    assert data["amount_unit"] is None
 
 
 def test_create_feeding_with_timestamp(client):
@@ -40,7 +79,12 @@ def test_create_feeding_with_timestamp(client):
     custom_time = "2026-04-05T08:00:00Z"
     resp = client.post(
         "/api/feedings",
-        json={"feeding_type": "bottle", "amount_oz": 4.0, "timestamp": custom_time},
+        json={
+            "feeding_type": "bottle",
+            "amount": 4.0,
+            "amount_unit": "oz",
+            "timestamp": custom_time,
+        },
     )
     assert resp.status_code == 201
     data = resp.json()
@@ -67,6 +111,40 @@ def test_update_feeding(client):
     resp = client.put(f"/api/feedings/{fid}", json={"duration_minutes": 20})
     assert resp.status_code == 200
     assert resp.json()["duration_minutes"] == 20
+
+
+def test_update_bottle_amount_and_unit(client):
+    create_resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 3.0, "amount_unit": "oz"},
+    )
+    fid = create_resp.json()["id"]
+    resp = client.put(f"/api/feedings/{fid}", json={"amount": 100, "amount_unit": "mL"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["amount"] == 100
+    assert data["amount_unit"] == "mL"
+
+
+def test_update_bottle_amount_requires_unit(client):
+    create_resp = client.post("/api/feedings", json={"feeding_type": "bottle"})
+    fid = create_resp.json()["id"]
+    resp = client.put(f"/api/feedings/{fid}", json={"amount": 100})
+    assert resp.status_code == 422
+
+
+def test_update_breast_feeding_normalizes_amount_unit(client):
+    create_resp = client.post("/api/feedings", json={"feeding_type": "bottle"})
+    fid = create_resp.json()["id"]
+    resp = client.put(
+        f"/api/feedings/{fid}",
+        json={"feeding_type": "breast_left", "amount": 100, "amount_unit": "mL"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["feeding_type"] == "breast_left"
+    assert data["amount"] is None
+    assert data["amount_unit"] is None
 
 
 def test_delete_feeding(client):
@@ -112,7 +190,10 @@ def test_feeding_stats_mixed_sessions(client):
         json={"feeding_type": "breast_right", "duration_minutes": 6, "session_id": session_id},
     )
     # One individual bottle feed
-    client.post("/api/feedings", json={"feeding_type": "bottle", "amount_oz": 3.0})
+    client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 3.0, "amount_unit": "oz"},
+    )
     resp = client.get("/api/feedings/stats")
     assert resp.status_code == 200
     assert resp.json()["today"] == 2  # one paired session + one bottle
@@ -208,8 +289,9 @@ def test_migration_adds_session_id_column(setup_db):
         poolclass=StaticPool,
     )
     with old_engine.connect() as conn:
-        conn.execute(text(
-            """
+        conn.execute(
+            text(
+                """
             CREATE TABLE feedings (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 timestamp DATETIME NOT NULL,
@@ -220,7 +302,8 @@ def test_migration_adds_session_id_column(setup_db):
                 created_at DATETIME
             )
             """
-        ))
+            )
+        )
         conn.commit()
 
     # Confirm the column is absent before migration
@@ -234,6 +317,9 @@ def test_migration_adds_session_id_column(setup_db):
     with old_engine.connect() as conn:
         post_cols = {c["name"] for c in inspect(conn).get_columns("feedings")}
     assert "session_id" in post_cols
+    assert "amount" in post_cols
+    assert "amount_unit" in post_cols
+    assert "amount_oz" not in post_cols
 
     # Running the migration a second time must be idempotent (no error)
     _run_migrations(bind=old_engine)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -93,7 +93,10 @@ def test_create_medication_all_valid_units(client):
 
 
 def test_list_medications(client):
-    client.post("/api/medications", json={"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"})
+    client.post(
+        "/api/medications",
+        json={"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"},
+    )
     resp = client.get("/api/medications")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
@@ -228,6 +231,21 @@ def test_export_csv(client):
     resp = client.get("/api/export?format=csv")
     assert resp.status_code == 200
     assert "text/csv" in resp.headers["content-type"]
+
+
+def test_export_csv_feeding_amount_columns(client):
+    client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 100, "amount_unit": "mL"},
+    )
+    resp = client.get("/api/export?format=csv")
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert "amount" in content
+    assert "amount_unit" in content
+    assert "amount_oz" not in content
+    assert "100.0" in content
+    assert "mL" in content
 
 
 def test_export_csv_medication_columns(client):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -11,6 +11,7 @@ user upgrading from an older release still ends up with:
 - ``saved_medications`` seeded from prior log entries so the autocomplete
   dropdown is non-empty on first use.
 """
+
 import sqlite3
 
 import pytest
@@ -62,6 +63,15 @@ def legacy_engine(tmp_path):
             ("2026-04-03 10:00:00", "tylenol", "2.5 ml", None, "2026-04-03 10:00:00"),
         ],
     )
+    raw.executemany(
+        "INSERT INTO feedings "
+        "(timestamp, feeding_type, duration_minutes, amount_oz, notes, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("2026-04-01 09:00:00", "bottle", None, 3.5, None, "2026-04-01 09:00:00"),
+            ("2026-04-01 10:00:00", "breast_left", 12, None, None, "2026-04-01 10:00:00"),
+        ],
+    )
     raw.commit()
     raw.close()
 
@@ -85,6 +95,19 @@ def test_migration_adds_split_dosage_columns(legacy_engine):
     assert "dosage_unit" in cols
 
 
+def test_migration_renames_feeding_amount_column(legacy_engine):
+    with legacy_engine.connect() as conn:
+        cols = {c["name"] for c in inspect(conn).get_columns("feedings")}
+        rows = conn.execute(
+            text("SELECT feeding_type, amount, amount_unit FROM feedings ORDER BY id")
+        ).fetchall()
+    assert "amount" in cols
+    assert "amount_unit" in cols
+    assert "amount_oz" not in cols
+    assert rows[0] == ("bottle", 3.5, "oz")
+    assert rows[1] == ("breast_left", None, None)
+
+
 def test_migration_drops_obsolete_dosage_column(legacy_engine):
     """The old NOT NULL ``dosage`` column must go — otherwise new medication
     saves fail with a NOT NULL constraint error (issue #30)."""
@@ -97,8 +120,7 @@ def test_migration_parses_existing_dosage_values(legacy_engine):
     with legacy_engine.connect() as conn:
         rows = conn.execute(
             text(
-                "SELECT medication_name, dosage_quantity, dosage_unit "
-                "FROM medications ORDER BY id"
+                "SELECT medication_name, dosage_quantity, dosage_unit FROM medications ORDER BY id"
             )
         ).fetchall()
     assert rows[0] == ("Tylenol", 2.5, "mL")
@@ -149,7 +171,11 @@ def test_migration_is_idempotent(legacy_engine):
     _run_migrations(bind=legacy_engine)
     with legacy_engine.connect() as conn:
         cols = {c["name"] for c in inspect(conn).get_columns("medications")}
+        feeding_cols = {c["name"] for c in inspect(conn).get_columns("feedings")}
         saved = conn.execute(text("SELECT COUNT(*) FROM saved_medications")).scalar()
     assert "dosage" not in cols
     assert "dosage_quantity" in cols
+    assert "amount" in feeding_cols
+    assert "amount_unit" in feeding_cols
+    assert "amount_oz" not in feeding_cols
     assert saved == 2


### PR DESCRIPTION
Replace hardcoded oz amounts with configurable bottle feed units. Users can now track bottle feedings in either ounces or milliliters.

Changes:
- Add amount_unit column to feedings table (oz or mL)
- Rename amount_oz column to amount for consistency
- Include database migration (idempotent, handles legacy data)
- Add unit selection in UI with default unit setting
- Validate that bottle feedings have both amount and unit
- Normalize amount/unit fields for non-bottle feeding types
- Format display amounts based on selected unit

The migration backfills existing bottle feedings with 'oz' unit.

Implements issue #41.