### PR TITLE
Add amount + unit for bottle feedings

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -106,21 +106,34 @@ def diaper_stats(db: Session) -> dict[str, int]:
 # --- Feedings ---
 
 
+def _format_bottle_amount(amount: float | None, amount_unit: str | None) -> str:
+    if amount is None or amount_unit is None:
+        return ""
+    if amount_unit == "mL":
+        return f"{amount:.0f} mL"
+    return f"{amount:.2f} oz"
+
+
 def create_feeding(
     db: Session,
     timestamp: datetime | None,
     feeding_type: str,
     duration_minutes: int | None,
-    amount_oz: float | None,
+    amount: float | None,
+    amount_unit: str | None,
     notes: str | None,
     session_id: str | None = None,
     bottle_type: str | None = None,
 ) -> Feeding:
+    if feeding_type != "bottle":
+        amount = None
+        amount_unit = None
     obj = Feeding(
         timestamp=timestamp or datetime.now(UTC),
         feeding_type=feeding_type,
         duration_minutes=duration_minutes,
-        amount_oz=amount_oz,
+        amount=amount,
+        amount_unit=amount_unit,
         notes=notes,
         session_id=session_id,
         bottle_type=bottle_type,
@@ -155,8 +168,12 @@ def update_feeding(db: Session, feeding_id: int, **kwargs) -> Feeding | None:
     obj = db.get(Feeding, feeding_id)
     if not obj:
         return None
+    target_type = kwargs.get("feeding_type", obj.feeding_type)
+    if target_type in {"breast_left", "breast_right"}:
+        kwargs["amount"] = None
+        kwargs["amount_unit"] = None
     for k, v in kwargs.items():
-        if v is not None:
+        if v is not None or k in {"amount", "amount_unit"}:
             setattr(obj, k, v)
     db.commit()
     db.refresh(obj)
@@ -444,9 +461,9 @@ def get_activities(
         if f.session_id:
             session_groups.setdefault(f.session_id, []).append(f)
         else:
-            if f.amount_oz:
+            if f.amount is not None and f.amount_unit:
                 bottle_label = "Formula" if f.bottle_type == "formula" else "Breastmilk"
-                detail = f"{bottle_label} · {f.amount_oz} oz"
+                detail = f"{bottle_label} · {_format_bottle_amount(f.amount, f.amount_unit)}"
             elif f.duration_minutes:
                 detail = f"{f.duration_minutes} min"
             else:

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -96,8 +96,54 @@ def _run_migrations(bind=None) -> None:
         if "session_id" not in existing_cols:
             conn.execute(text("ALTER TABLE feedings ADD COLUMN session_id TEXT"))
             conn.commit()
+            existing_cols.add("session_id")
         if "bottle_type" not in existing_cols:
             conn.execute(text("ALTER TABLE feedings ADD COLUMN bottle_type TEXT"))
+            conn.commit()
+            existing_cols.add("bottle_type")
+        if "amount_unit" not in existing_cols:
+            conn.execute(text("ALTER TABLE feedings ADD COLUMN amount_unit TEXT"))
+            conn.commit()
+            existing_cols.add("amount_unit")
+        conn.execute(
+            text(
+                "UPDATE feedings SET amount_unit = 'oz' "
+                "WHERE feeding_type = 'bottle' AND amount_unit IS NULL"
+            )
+        )
+        conn.commit()
+        if "amount_oz" in existing_cols and "amount" not in existing_cols:
+            conn.execute(text("PRAGMA foreign_keys=off"))
+            conn.execute(
+                text(
+                    "CREATE TABLE feedings_new ("
+                    "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+                    "timestamp DATETIME NOT NULL, "
+                    "feeding_type VARCHAR NOT NULL, "
+                    "duration_minutes INTEGER, "
+                    "amount FLOAT, "
+                    "amount_unit VARCHAR, "
+                    "notes TEXT, "
+                    "session_id VARCHAR, "
+                    "bottle_type VARCHAR, "
+                    "created_at DATETIME)"
+                )
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO feedings_new "
+                    "(id, timestamp, feeding_type, duration_minutes, amount, amount_unit, "
+                    "notes, session_id, bottle_type, created_at) "
+                    "SELECT id, timestamp, feeding_type, duration_minutes, amount_oz, amount_unit, "
+                    "notes, session_id, bottle_type, created_at FROM feedings"
+                )
+            )
+            conn.execute(text("DROP TABLE feedings"))
+            conn.execute(text("ALTER TABLE feedings_new RENAME TO feedings"))
+            conn.execute(
+                text("CREATE INDEX IF NOT EXISTS idx_feeding_timestamp ON feedings (timestamp)")
+            )
+            conn.execute(text("PRAGMA foreign_keys=on"))
             conn.commit()
 
         insp = inspect(conn)
@@ -120,8 +166,8 @@ def _run_migrations(bind=None) -> None:
                 qty, unit = _parse_dosage(dosage_text or "")
                 conn.execute(
                     text(
-                        "UPDATE medications SET dosage_quantity = :qty, "
-                        "dosage_unit = :unit WHERE id = :id"
+                        "UPDATE medications SET dosage_quantity = :qty, dosage_unit = :unit "
+                        "WHERE id = :id"
                     ),
                     {"qty": qty, "unit": unit, "id": row_id},
                 )

--- a/src/puffin/models.py
+++ b/src/puffin/models.py
@@ -51,7 +51,8 @@ class Feeding(Base):
         String, nullable=False
     )  # breast_left, breast_right, bottle
     duration_minutes: Mapped[int | None] = mapped_column(Integer, nullable=True)
-    amount_oz: Mapped[float | None] = mapped_column(Float, nullable=True)
+    amount: Mapped[float | None] = mapped_column(Float, nullable=True)
+    amount_unit: Mapped[str | None] = mapped_column(String, nullable=True)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     session_id: Mapped[str | None] = mapped_column(String, nullable=True)
     bottle_type: Mapped[str | None] = mapped_column(String, nullable=True)  # breastmilk, formula

--- a/src/puffin/routers/dashboard.py
+++ b/src/puffin/routers/dashboard.py
@@ -16,6 +16,14 @@ router = APIRouter(prefix="/api", tags=["dashboard"])
 _PDF_MAX_CELL_LENGTH = 40  # max characters per cell before truncation
 
 
+def _format_bottle_amount(amount: float | None, amount_unit: str | None) -> str:
+    if amount is None or amount_unit is None:
+        return ""
+    if amount_unit == "mL":
+        return f"{amount:.0f} mL"
+    return f"{amount:.2f} oz"
+
+
 @router.get("/dashboard", response_model=DashboardSummary)
 def get_dashboard(
     date: str | None = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"),
@@ -105,13 +113,13 @@ def export_data(
         _pdf_section(
             pdf,
             "Feedings",
-            ["Time", "Type", "Duration (min)", "Amount (oz)", "Notes"],
+            ["Time", "Type", "Duration (min)", "Amount", "Notes"],
             [
                 [
                     _fmt_ts(f.timestamp),
                     str(f.feeding_type),
                     str(f.duration_minutes) if f.duration_minutes is not None else "",
-                    str(f.amount_oz) if f.amount_oz is not None else "",
+                    _format_bottle_amount(f.amount, f.amount_unit),
                     f.notes or "",
                 ]
                 for f in feedings
@@ -167,7 +175,16 @@ def export_data(
     writer.writerow([])
     writer.writerow(["--- Feedings ---"])
     writer.writerow(
-        ["id", "timestamp", "feeding_type", "duration_minutes", "amount_oz", "notes", "created_at"]
+        [
+            "id",
+            "timestamp",
+            "feeding_type",
+            "duration_minutes",
+            "amount",
+            "amount_unit",
+            "notes",
+            "created_at",
+        ]
     )
     for f in feedings:
         writer.writerow(
@@ -176,7 +193,8 @@ def export_data(
                 f.timestamp,
                 f.feeding_type,
                 f.duration_minutes,
-                f.amount_oz,
+                f.amount,
+                f.amount_unit,
                 f.notes,
                 f.created_at,
             ]

--- a/src/puffin/routers/feedings.py
+++ b/src/puffin/routers/feedings.py
@@ -17,7 +17,8 @@ def create_feeding(data: FeedingCreate, db: Session = Depends(get_db)):
         timestamp=data.timestamp,
         feeding_type=data.feeding_type.value,
         duration_minutes=data.duration_minutes,
-        amount_oz=data.amount_oz,
+        amount=data.amount,
+        amount_unit=data.amount_unit.value if data.amount_unit else None,
         notes=data.notes,
         session_id=data.session_id,
         bottle_type=data.bottle_type.value if data.bottle_type else None,
@@ -52,6 +53,15 @@ def get_feeding(feeding_id: int, db: Session = Depends(get_db)):
 
 @router.put("/{feeding_id}", response_model=FeedingResponse)
 def update_feeding(feeding_id: int, data: FeedingUpdate, db: Session = Depends(get_db)):
+    existing = crud.get_feeding(db, feeding_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Feeding not found")
+    target_type = data.feeding_type.value if data.feeding_type else existing.feeding_type
+    if target_type == "bottle" and (data.amount is None) != (data.amount_unit is None):
+        raise HTTPException(
+            status_code=422,
+            detail="Bottle feeds require amount and amount_unit together",
+        )
     updates = {}
     if data.timestamp is not None:
         updates["timestamp"] = data.timestamp
@@ -59,16 +69,15 @@ def update_feeding(feeding_id: int, data: FeedingUpdate, db: Session = Depends(g
         updates["feeding_type"] = data.feeding_type.value
     if data.duration_minutes is not None:
         updates["duration_minutes"] = data.duration_minutes
-    if data.amount_oz is not None:
-        updates["amount_oz"] = data.amount_oz
+    if data.amount is not None:
+        updates["amount"] = data.amount
+    if data.amount_unit is not None:
+        updates["amount_unit"] = data.amount_unit.value
     if data.notes is not None:
         updates["notes"] = data.notes
     if data.bottle_type is not None:
         updates["bottle_type"] = data.bottle_type.value
-    obj = crud.update_feeding(db, feeding_id, **updates)
-    if not obj:
-        raise HTTPException(status_code=404, detail="Feeding not found")
-    return obj
+    return crud.update_feeding(db, feeding_id, **updates)
 
 
 @router.delete("/{feeding_id}", status_code=204)

--- a/src/puffin/schemas.py
+++ b/src/puffin/schemas.py
@@ -1,8 +1,9 @@
 from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
+from typing import Self
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, field_validator, model_validator
 
 # --- Enums ---
 
@@ -23,6 +24,11 @@ class FeedingType(StrEnum):
 class BottleType(StrEnum):
     breastmilk = "breastmilk"
     formula = "formula"
+
+
+class BottleUnit(StrEnum):
+    oz = "oz"
+    ml = "mL"
 
 
 class TemperatureLocation(StrEnum):
@@ -74,19 +80,41 @@ class FeedingCreate(BaseModel):
     timestamp: datetime | None = None
     feeding_type: FeedingType
     duration_minutes: int | None = None
-    amount_oz: float | None = None
+    amount: float | None = None
+    amount_unit: BottleUnit | None = None
     notes: str | None = None
     session_id: str | None = None
     bottle_type: BottleType | None = None
+
+    @model_validator(mode="after")
+    def validate_bottle_amount(self) -> Self:
+        if self.feeding_type == FeedingType.bottle:
+            if (self.amount is None) != (self.amount_unit is None):
+                raise ValueError("Bottle feeds require amount and amount_unit together")
+        else:
+            self.amount = None
+            self.amount_unit = None
+        return self
 
 
 class FeedingUpdate(BaseModel):
     timestamp: datetime | None = None
     feeding_type: FeedingType | None = None
     duration_minutes: int | None = None
-    amount_oz: float | None = None
+    amount: float | None = None
+    amount_unit: BottleUnit | None = None
     notes: str | None = None
     bottle_type: BottleType | None = None
+
+    @model_validator(mode="after")
+    def validate_bottle_amount(self) -> Self:
+        if self.feeding_type == FeedingType.bottle:
+            if (self.amount is None) != (self.amount_unit is None):
+                raise ValueError("Bottle feeds require amount and amount_unit together")
+        elif self.feeding_type in {FeedingType.breast_left, FeedingType.breast_right}:
+            self.amount = None
+            self.amount_unit = None
+        return self
 
 
 class FeedingResponse(BaseModel):
@@ -96,7 +124,8 @@ class FeedingResponse(BaseModel):
     timestamp: datetime
     feeding_type: FeedingType
     duration_minutes: int | None
-    amount_oz: float | None
+    amount: float | None
+    amount_unit: BottleUnit | None
     notes: str | None
     session_id: str | None
     bottle_type: BottleType | None

--- a/src/puffin/seed.py
+++ b/src/puffin/seed.py
@@ -77,7 +77,8 @@ def generate_feedings(day_offset: int, base_date: datetime, now: datetime) -> li
                 Feeding(
                     timestamp=current_time,
                     feeding_type="bottle",
-                    amount_oz=round(random.uniform(1.0, 4.0), 1),
+                    amount=round(random.uniform(1.0, 4.0), 1),
+                    amount_unit="oz",
                     notes=random.choice(FEEDING_NOTES),
                     created_at=current_time,
                 )

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -46,12 +46,41 @@ const BREAST_RIGHT_KEY = 'puffin-breast-right-name';
 const DEFAULT_LEFT_NAME = 'Left';
 const DEFAULT_RIGHT_NAME = 'Right';
 
-/* ===== Bottle Type ===== */
+/* ===== Bottle Defaults ===== */
 const BOTTLE_TYPE_KEY = 'puffin-bottle-type-default';
+const BOTTLE_UNIT_KEY = 'defaultBottleUnit';
 const DEFAULT_BOTTLE_TYPE = 'breastmilk';
+const DEFAULT_BOTTLE_UNIT = 'oz';
 
 function getDefaultBottleType() {
     return localStorage.getItem(BOTTLE_TYPE_KEY) || DEFAULT_BOTTLE_TYPE;
+}
+
+function getDefaultBottleUnit() {
+    const unit = localStorage.getItem(BOTTLE_UNIT_KEY) || DEFAULT_BOTTLE_UNIT;
+    return unit === 'mL' ? 'mL' : 'oz';
+}
+
+function validateBottleAmountUnit(amount, unit) {
+    if (unit === 'mL' && !Number.isInteger(Number(amount))) {
+        showToast('mL amounts must be whole numbers');
+        return false;
+    }
+    return true;
+}
+
+function updateBottleUnitLabels() {
+    const defaultUnit = getDefaultBottleUnit();
+    const selects = [
+        document.getElementById('feeding-bottle-unit-timer-select'),
+        document.getElementById('feeding-bottle-unit-manual-select'),
+    ];
+    for (const sel of selects) {
+        if (!sel) continue;
+        sel.querySelector('option[value="oz"]').textContent = 'oz' + (defaultUnit === 'oz' ? ' (default)' : '');
+        sel.querySelector('option[value="mL"]').textContent = 'mL' + (defaultUnit === 'mL' ? ' (default)' : '');
+        sel.value = defaultUnit;
+    }
 }
 
 function updateBottleTypeLabels() {
@@ -125,6 +154,7 @@ function openModal(id) {
         loadLastBreastFeeding();
         loadNoteSuggestions('/api/feedings', 'feeding-note-suggestions', 'feeding-notes');
         updateBottleTypeLabels();
+        updateBottleUnitLabels();
     } else if (id === 'diaper-modal') {
         loadNoteSuggestions('/api/diapers', 'diaper-note-suggestions', 'diaper-notes');
     } else if (id === 'health-modal') {
@@ -152,7 +182,7 @@ function closeModal(id) {
     if (id === 'feeding-modal') {
         document.getElementById('feeding-timer-mode').classList.remove('hidden');
         document.getElementById('feeding-manual-mode').classList.add('hidden');
-        document.getElementById('feeding-bottle-oz-timer').classList.add('hidden');
+        document.getElementById('feeding-bottle-timer').classList.add('hidden');
         const timerRow = document.getElementById('timer-toggle-row');
         if (timerRow) timerRow.classList.remove('hidden');
         document.getElementById('feeding-save-btn').disabled = true;
@@ -574,8 +604,8 @@ function initFeedingForm() {
     const timerToggleRow = document.getElementById('timer-toggle-row');
     const timerMode = document.getElementById('feeding-timer-mode');
     const manualMode = document.getElementById('feeding-manual-mode');
-    const bottleOzTimerGroup = document.getElementById('feeding-bottle-oz-timer');
-    const bottleOzTimerInput = document.getElementById('feeding-bottle-oz-timer-input');
+    const bottleOzTimerGroup = document.getElementById('feeding-bottle-timer');
+    const bottleOzTimerInput = document.getElementById('feeding-bottle-timer-input');
     const saveBtn = document.getElementById('feeding-save-btn');
 
     function updateMode() {
@@ -600,14 +630,14 @@ function initFeedingForm() {
             return;
         }
         if (ft === 'bottle') {
-            // Bottle: hide timer toggle, show ounces, require a value, set button to Save
+            // Bottle: hide timer toggle, show amount, require a value, set button to Save
             if (timerToggleRow) timerToggleRow.classList.add('hidden');
             bottleOzTimerGroup.classList.remove('hidden');
             saveBtn.textContent = 'Save';
-            const hasOz = !!bottleOzTimerInput.value;
-            saveBtn.disabled = !hasOz;
+            const hasAmount = !!bottleOzTimerInput.value;
+            saveBtn.disabled = !hasAmount;
         } else {
-            // Breast: show timer toggle, hide ounces, enable Start
+            // Breast: show timer toggle, hide amount, enable Start
             if (timerToggleRow) timerToggleRow.classList.remove('hidden');
             bottleOzTimerGroup.classList.add('hidden');
             saveBtn.textContent = 'Start';
@@ -618,7 +648,7 @@ function initFeedingForm() {
     function updateManualBtnState() {
         const l = document.getElementById('feeding-left-duration').value;
         const r = document.getElementById('feeding-right-duration').value;
-        const b = document.getElementById('feeding-bottle-oz').value;
+        const b = document.getElementById('feeding-bottle').value;
         saveBtn.disabled = !(l || r || b);
     }
 
@@ -633,11 +663,10 @@ function initFeedingForm() {
         }
     });
 
-    // Recompute when ounces entered in timer mode
     bottleOzTimerInput.addEventListener('input', updateTimerBtnState);
 
     // Manual mode: enable save when any field is entered
-    ['feeding-left-duration', 'feeding-right-duration', 'feeding-bottle-oz'].forEach(id => {
+    ['feeding-left-duration', 'feeding-right-duration', 'feeding-bottle'].forEach(id => {
         document.getElementById(id).addEventListener('input', updateManualBtnState);
     });
 
@@ -839,14 +868,17 @@ function initForms() {
             if (!feedingType) { showToast('Please select a feeding type'); return; }
 
             if (feedingType === 'bottle') {
-                const oz = document.getElementById('feeding-bottle-oz-timer-input').value;
-                if (!oz) { showToast('Please enter ounces'); return; }
+                const amount = document.getElementById('feeding-bottle-timer-input').value;
+                const amountUnit = document.getElementById('feeding-bottle-unit-timer-select').value;
+                if (!amount) { showToast(`Please enter ${amountUnit}`); return; }
+                if (!validateBottleAmountUnit(amount, amountUnit)) return;
                 const bottleType = document.getElementById('feeding-bottle-type-timer-select').value;
                 saveBtn.disabled = true;
                 try {
                     await api.post('/api/feedings', {
                         feeding_type: 'bottle',
-                        amount_oz: parseFloat(oz),
+                        amount: parseFloat(amount),
+                        amount_unit: amountUnit,
                         bottle_type: bottleType,
                         notes,
                         timestamp,
@@ -871,12 +903,14 @@ function initForms() {
         // Manual mode: create entries for each non-empty field
         const leftDur = document.getElementById('feeding-left-duration').value;
         const rightDur = document.getElementById('feeding-right-duration').value;
-        const bottleOz = document.getElementById('feeding-bottle-oz').value;
+        const bottleAmount = document.getElementById('feeding-bottle').value;
+        const bottleUnit = document.getElementById('feeding-bottle-unit-manual-select').value;
 
-        if (!leftDur && !rightDur && !bottleOz) {
+        if (!leftDur && !rightDur && !bottleAmount) {
             showToast('Please enter at least one value');
             return;
         }
+        if (bottleAmount && !validateBottleAmountUnit(bottleAmount, bottleUnit)) return;
 
         saveBtn.disabled = true;
         try {
@@ -906,11 +940,12 @@ function initForms() {
                 promises.push(api.post('/api/feedings', body));
                 notesAttached = true;
             }
-            if (bottleOz) {
+            if (bottleAmount) {
                 const bottleType = document.getElementById('feeding-bottle-type-manual-select').value;
                 promises.push(api.post('/api/feedings', {
                     feeding_type: 'bottle',
-                    amount_oz: parseFloat(bottleOz),
+                    amount: parseFloat(bottleAmount),
+                    amount_unit: bottleUnit,
                     bottle_type: bottleType,
                     notes: notesAttached ? undefined : notes,
                     timestamp,
@@ -1106,6 +1141,7 @@ function buildFeedingEditFields(data, secondaryData = null) {
     const isBottle = data.feeding_type === 'bottle';
     const names = getBreastNames();
     const bottleTypeVal = data.bottle_type || 'breastmilk';
+    const bottleUnitVal = data.amount_unit || getDefaultBottleUnit();
     return `
         <div class="form-group">
             <label>Type</label>
@@ -1121,8 +1157,14 @@ function buildFeedingEditFields(data, secondaryData = null) {
             <input type="number" id="edit-duration" min="1" max="120" value="${data.duration_minutes || ''}">
         </div>
         <div class="form-group" id="edit-oz-group" ${isBottle ? '' : 'style="display:none"'}>
-            <label for="edit-amount-oz">Amount (oz)</label>
-            <input type="number" id="edit-amount-oz" min="0.01" max="12.00" step="0.01" value="${data.amount_oz || ''}">
+            <label for="edit-amount">Amount</label>
+            <div class="input-group">
+                <input type="number" id="edit-amount" min="0.01" step="0.01" value="${data.amount || ''}">
+                <select id="edit-amount-unit">
+                    <option value="oz" ${bottleUnitVal === 'oz' ? 'selected' : ''}>oz</option>
+                    <option value="mL" ${bottleUnitVal === 'mL' ? 'selected' : ''}>mL</option>
+                </select>
+            </div>
         </div>
         <div class="form-group" id="edit-bottle-type-group" ${isBottle ? '' : 'style="display:none"'}>
             <label for="edit-bottle-type">Bottle Type</label>
@@ -1224,8 +1266,13 @@ function buildEditBody(type) {
         case 'feeding': {
             body.feeding_type = document.getElementById('edit-feeding-type').value;
             if (body.feeding_type === 'bottle') {
-                const oz = document.getElementById('edit-amount-oz').value;
-                if (oz) body.amount_oz = parseFloat(oz);
+                const amount = document.getElementById('edit-amount').value;
+                const amountUnit = document.getElementById('edit-amount-unit').value;
+                if (amount) {
+                    if (!validateBottleAmountUnit(amount, amountUnit)) return null;
+                    body.amount = parseFloat(amount);
+                    body.amount_unit = amountUnit;
+                }
                 const btEl = document.getElementById('edit-bottle-type');
                 if (btEl) body.bottle_type = btEl.value;
             } else {
@@ -1261,7 +1308,7 @@ function initEditOptionButtons() {
             btn.classList.add('selected');
             document.getElementById(field).value = value;
 
-            // Toggle duration vs ounces/bottle-type for feeding edits
+            // Toggle duration vs amount/bottle-type for feeding edits
             if (field === 'edit-feeding-type') {
                 const durGroup = document.getElementById('edit-duration-group');
                 const ozGroup = document.getElementById('edit-oz-group');
@@ -1310,7 +1357,9 @@ function initEditForm() {
                     api.put(`/api/feedings/${rightIdEl.value}`, rightBody),
                 ]);
             } else {
-                await api.put(endpoints[type], buildEditBody(type));
+                const body = buildEditBody(type);
+                if (!body) return;
+                await api.put(endpoints[type], body);
             }
             closeModal('edit-modal');
             showToast('Updated!');
@@ -1532,6 +1581,8 @@ function initSettings() {
         document.getElementById('settings-left-name').value = names.left;
         document.getElementById('settings-right-name').value = names.right;
         document.getElementById('settings-bottle-type').value = getDefaultBottleType();
+        document.getElementById('settings-bottle-unit').value = getDefaultBottleUnit();
+        updateBottleUnitLabels();
         openModal('settings-modal');
     });
 
@@ -1540,12 +1591,15 @@ function initSettings() {
         const leftName = document.getElementById('settings-left-name').value.trim() || DEFAULT_LEFT_NAME;
         const rightName = document.getElementById('settings-right-name').value.trim() || DEFAULT_RIGHT_NAME;
         const bottleType = document.getElementById('settings-bottle-type').value;
+        const bottleUnit = document.getElementById('settings-bottle-unit').value;
         localStorage.setItem(BREAST_LEFT_KEY, leftName);
         localStorage.setItem(BREAST_RIGHT_KEY, rightName);
         localStorage.setItem(BOTTLE_TYPE_KEY, bottleType);
+        localStorage.setItem(BOTTLE_UNIT_KEY, bottleUnit);
         closeModal('settings-modal');
         updateBreastLabels();
         updateBottleTypeLabels();
+        updateBottleUnitLabels();
         if (getTimerState()) showTimerUI();
         showToast('Settings saved!');
     });
@@ -1587,6 +1641,7 @@ document.addEventListener('DOMContentLoaded', () => {
     initExport();
     updateBreastLabels();
     updateBottleTypeLabels();
+    updateBottleUnitLabels();
     loadDashboard();
 
     // Theme toggle

--- a/templates/index.html
+++ b/templates/index.html
@@ -139,10 +139,14 @@
                         </div>
                         <input type="hidden" id="feeding-type">
                     </div>
-                    <div id="feeding-bottle-oz-timer" class="form-group hidden">
-                        <label>Amount &amp; Type</label>
+                    <div id="feeding-bottle-timer" class="form-group hidden">
+                        <label>Amount</label>
                         <div class="input-group">
-                            <input type="number" id="feeding-bottle-oz-timer-input" min="0.01" max="12.00" step="0.01" placeholder="oz">
+                            <input type="number" id="feeding-bottle-timer-input" min="0.01" step="0.01">
+                            <select id="feeding-bottle-unit-timer-select">
+                                <option value="oz">oz</option>
+                                <option value="mL">mL</option>
+                            </select>
                             <select id="feeding-bottle-type-timer-select">
                                 <option value="breastmilk">Breastmilk (default)</option>
                                 <option value="formula">Formula</option>
@@ -164,7 +168,11 @@
                     <div class="form-group">
                         <label>🍼 Bottle</label>
                         <div class="input-group">
-                            <input type="number" id="feeding-bottle-oz" min="0.01" max="12.00" step="0.01" placeholder="oz">
+                            <input type="number" id="feeding-bottle" min="0.01" step="0.01">
+                            <select id="feeding-bottle-unit-manual-select">
+                                <option value="oz">oz</option>
+                                <option value="mL">mL</option>
+                            </select>
                             <select id="feeding-bottle-type-manual-select">
                                 <option value="breastmilk">Breastmilk (default)</option>
                                 <option value="formula">Formula</option>
@@ -322,6 +330,13 @@
                     <select id="settings-bottle-type">
                         <option value="breastmilk">Breastmilk</option>
                         <option value="formula">Formula</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="settings-bottle-unit">Default bottle unit</label>
+                    <select id="settings-bottle-unit">
+                        <option value="oz">oz</option>
+                        <option value="mL">mL</option>
                     </select>
                 </div>
                 <div class="form-actions">

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -52,6 +52,41 @@ def test_list_activities_paired_session_merged(client):
     assert "Right" in feeding_activities[0]["detail"]
 
 
+def test_list_activities_formats_bottle_oz(client):
+    from datetime import UTC, datetime
+
+    client.post(
+        "/api/feedings",
+        json={
+            "feeding_type": "bottle",
+            "amount": 3.5,
+            "amount_unit": "oz",
+            "bottle_type": "formula",
+        },
+    )
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    resp = client.get(f"/api/activities?date={today}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["detail"] == "Formula · 3.50 oz"
+
+
+def test_list_activities_formats_bottle_ml(client):
+    from datetime import UTC, datetime
+
+    client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 100, "amount_unit": "mL"},
+    )
+
+    today = datetime.now(UTC).strftime("%Y-%m-%d")
+    resp = client.get(f"/api/activities?date={today}")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[0]["detail"] == "Breastmilk · 100 mL"
+
+
 def test_list_activities_empty(client):
     """No activities for a date far in the past."""
     resp = client.get("/api/activities?date=2000-01-01")

--- a/tests/test_feedings.py
+++ b/tests/test_feedings.py
@@ -26,13 +26,52 @@ def test_create_bottle_feeding(client):
 def test_create_bottle_feeding_with_oz(client):
     resp = client.post(
         "/api/feedings",
-        json={"feeding_type": "bottle", "amount_oz": 3.5},
+        json={"feeding_type": "bottle", "amount": 3.5, "amount_unit": "oz"},
     )
     assert resp.status_code == 201
     data = resp.json()
     assert data["feeding_type"] == "bottle"
-    assert data["amount_oz"] == 3.5
+    assert data["amount"] == 3.5
+    assert data["amount_unit"] == "oz"
     assert data["duration_minutes"] is None
+
+
+def test_create_bottle_feeding_with_ml(client):
+    resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 120, "amount_unit": "mL"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["amount"] == 120
+    assert data["amount_unit"] == "mL"
+
+
+def test_create_bottle_feeding_amount_requires_unit(client):
+    resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 3.5},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_bottle_feeding_unit_requires_amount(client):
+    resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount_unit": "oz"},
+    )
+    assert resp.status_code == 422
+
+
+def test_create_breast_feeding_normalizes_amount_unit(client):
+    resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "breast_left", "amount": 3.5, "amount_unit": "oz"},
+    )
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["amount"] is None
+    assert data["amount_unit"] is None
 
 
 def test_create_feeding_with_timestamp(client):
@@ -40,7 +79,12 @@ def test_create_feeding_with_timestamp(client):
     custom_time = "2026-04-05T08:00:00Z"
     resp = client.post(
         "/api/feedings",
-        json={"feeding_type": "bottle", "amount_oz": 4.0, "timestamp": custom_time},
+        json={
+            "feeding_type": "bottle",
+            "amount": 4.0,
+            "amount_unit": "oz",
+            "timestamp": custom_time,
+        },
     )
     assert resp.status_code == 201
     data = resp.json()
@@ -67,6 +111,40 @@ def test_update_feeding(client):
     resp = client.put(f"/api/feedings/{fid}", json={"duration_minutes": 20})
     assert resp.status_code == 200
     assert resp.json()["duration_minutes"] == 20
+
+
+def test_update_bottle_amount_and_unit(client):
+    create_resp = client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 3.0, "amount_unit": "oz"},
+    )
+    fid = create_resp.json()["id"]
+    resp = client.put(f"/api/feedings/{fid}", json={"amount": 100, "amount_unit": "mL"})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["amount"] == 100
+    assert data["amount_unit"] == "mL"
+
+
+def test_update_bottle_amount_requires_unit(client):
+    create_resp = client.post("/api/feedings", json={"feeding_type": "bottle"})
+    fid = create_resp.json()["id"]
+    resp = client.put(f"/api/feedings/{fid}", json={"amount": 100})
+    assert resp.status_code == 422
+
+
+def test_update_breast_feeding_normalizes_amount_unit(client):
+    create_resp = client.post("/api/feedings", json={"feeding_type": "bottle"})
+    fid = create_resp.json()["id"]
+    resp = client.put(
+        f"/api/feedings/{fid}",
+        json={"feeding_type": "breast_left", "amount": 100, "amount_unit": "mL"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["feeding_type"] == "breast_left"
+    assert data["amount"] is None
+    assert data["amount_unit"] is None
 
 
 def test_delete_feeding(client):
@@ -112,7 +190,10 @@ def test_feeding_stats_mixed_sessions(client):
         json={"feeding_type": "breast_right", "duration_minutes": 6, "session_id": session_id},
     )
     # One individual bottle feed
-    client.post("/api/feedings", json={"feeding_type": "bottle", "amount_oz": 3.0})
+    client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 3.0, "amount_unit": "oz"},
+    )
     resp = client.get("/api/feedings/stats")
     assert resp.status_code == 200
     assert resp.json()["today"] == 2  # one paired session + one bottle
@@ -236,6 +317,9 @@ def test_migration_adds_session_id_column(setup_db):
     with old_engine.connect() as conn:
         post_cols = {c["name"] for c in inspect(conn).get_columns("feedings")}
     assert "session_id" in post_cols
+    assert "amount" in post_cols
+    assert "amount_unit" in post_cols
+    assert "amount_oz" not in post_cols
 
     # Running the migration a second time must be idempotent (no error)
     _run_migrations(bind=old_engine)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -233,6 +233,21 @@ def test_export_csv(client):
     assert "text/csv" in resp.headers["content-type"]
 
 
+def test_export_csv_feeding_amount_columns(client):
+    client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 100, "amount_unit": "mL"},
+    )
+    resp = client.get("/api/export?format=csv")
+    assert resp.status_code == 200
+    content = resp.content.decode()
+    assert "amount" in content
+    assert "amount_unit" in content
+    assert "amount_oz" not in content
+    assert "100.0" in content
+    assert "mL" in content
+
+
 def test_export_csv_medication_columns(client):
     client.post(
         "/api/medications",

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -63,6 +63,15 @@ def legacy_engine(tmp_path):
             ("2026-04-03 10:00:00", "tylenol", "2.5 ml", None, "2026-04-03 10:00:00"),
         ],
     )
+    raw.executemany(
+        "INSERT INTO feedings "
+        "(timestamp, feeding_type, duration_minutes, amount_oz, notes, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("2026-04-01 09:00:00", "bottle", None, 3.5, None, "2026-04-01 09:00:00"),
+            ("2026-04-01 10:00:00", "breast_left", 12, None, None, "2026-04-01 10:00:00"),
+        ],
+    )
     raw.commit()
     raw.close()
 
@@ -84,6 +93,68 @@ def test_migration_adds_split_dosage_columns(legacy_engine):
         cols = {c["name"] for c in inspect(conn).get_columns("medications")}
     assert "dosage_quantity" in cols
     assert "dosage_unit" in cols
+
+
+def test_migration_renames_feeding_amount_column(legacy_engine):
+    with legacy_engine.connect() as conn:
+        cols = {c["name"] for c in inspect(conn).get_columns("feedings")}
+        rows = conn.execute(
+            text("SELECT feeding_type, amount, amount_unit FROM feedings ORDER BY id")
+        ).fetchall()
+    assert "amount" in cols
+    assert "amount_unit" in cols
+    assert "amount_oz" not in cols
+    assert rows[0] == ("bottle", 3.5, "oz")
+    assert rows[1] == ("breast_left", None, None)
+
+
+def test_migration_adds_amount_unit_to_current_amount_schema(tmp_path):
+    db_path = tmp_path / "amount_without_unit.db"
+    raw = sqlite3.connect(db_path)
+    raw.executescript(
+        """
+        CREATE TABLE feedings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME NOT NULL,
+            feeding_type TEXT NOT NULL,
+            duration_minutes INTEGER,
+            amount REAL,
+            notes TEXT,
+            session_id TEXT,
+            bottle_type TEXT,
+            created_at DATETIME
+        );
+        INSERT INTO feedings
+            (timestamp, feeding_type, duration_minutes, amount, notes, created_at)
+        VALUES
+            ('2026-04-01 09:00:00', 'bottle', NULL, 120, NULL, '2026-04-01 09:00:00'),
+            ('2026-04-01 10:00:00', 'breast_left', 12, NULL, NULL, '2026-04-01 10:00:00');
+        """
+    )
+    raw.commit()
+    raw.close()
+
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    try:
+        _run_migrations(bind=engine)
+        _run_migrations(bind=engine)
+        with engine.connect() as conn:
+            cols = {c["name"] for c in inspect(conn).get_columns("feedings")}
+            rows = conn.execute(
+                text("SELECT feeding_type, amount, amount_unit FROM feedings ORDER BY id")
+            ).fetchall()
+    finally:
+        engine.dispose()
+
+    assert "amount" in cols
+    assert "amount_unit" in cols
+    assert "amount_oz" not in cols
+    assert rows[0] == ("bottle", 120.0, "oz")
+    assert rows[1] == ("breast_left", None, None)
 
 
 def test_migration_drops_obsolete_dosage_column(legacy_engine):
@@ -149,7 +220,11 @@ def test_migration_is_idempotent(legacy_engine):
     _run_migrations(bind=legacy_engine)
     with legacy_engine.connect() as conn:
         cols = {c["name"] for c in inspect(conn).get_columns("medications")}
+        feeding_cols = {c["name"] for c in inspect(conn).get_columns("feedings")}
         saved = conn.execute(text("SELECT COUNT(*) FROM saved_medications")).scalar()
     assert "dosage" not in cols
     assert "dosage_quantity" in cols
+    assert "amount" in feeding_cols
+    assert "amount_unit" in feeding_cols
+    assert "amount_oz" not in feeding_cols
     assert saved == 2


### PR DESCRIPTION
Replace amount_oz with a generic amount + amount_unit (oz/mL) across models, schemas, CRUD, routers, templates, and JS. Add validation so bottle feeds require both amount and amount_unit and normalize/clear amounts for non-bottle feedings. Implement DB migrations to add amount_unit, migrate amount_oz -> amount, and backfill existing bottle rows with 'oz'. Update CSV/PDF export columns and UI to support unit selection, defaults, and mL integer validation. Tests updated/added to cover formatting, API validation, updates, and migrations.

Implements issue #41.