### PR TITLE
Make TZ configuration discoverable instead of silently defaulting to UTC

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ docker run -d \
   --name puffin \
   -p 8000:8000 \
   -v puffin-data:/data \
+  -e TZ=America/New_York \
   ghcr.io/pid1/puffin:latest
 ```
 
@@ -45,6 +46,7 @@ Then open [http://localhost:8000](http://localhost:8000).
 ### Environment Variables
 
 - `PUFFIN_DB_PATH` — Path to the SQLite database file (default: `/data/puffin.db`). Normally you don't need to change this.
+- `TZ` — IANA timezone name (e.g. `America/New_York`) used to decide where one day ends and the next begins (default: `UTC`). **Set this to your local timezone.** Without it, an evening log west of UTC is counted as tomorrow — a diaper logged at 21:10 US Central lands on the next UTC day, so it won't show up in today's dashboard counts or timeline until midnight UTC. An unrecognized value falls back to UTC.
 
 ## Development
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -4,6 +4,14 @@ let
   setupCommands = [
     "install-deps"
   ];
+
+  # Day boundaries ("today" counts, timeline) come from TZ; it defaults to
+  # UTC in the app, which is wrong for anyone west of it. Fall back to the
+  # host's zone so dev matches what the browser shows.
+  exportTz = ''
+    export TZ="''${TZ:-$(readlink /etc/localtime 2>/dev/null | sed 's|.*/zoneinfo/||')}"
+    export TZ="''${TZ:-UTC}"
+  '';
 in
 {
   # Packages
@@ -33,10 +41,14 @@ in
     setup.exec = lib.concatStringsSep " && " setupCommands;
 
     # Interactive dev commands
-    dev.exec = "uv run uvicorn puffin.main:app --reload --host 0.0.0.0 --port 8000";
+    dev.exec = ''
+      ${exportTz}
+      uv run uvicorn puffin.main:app --reload --host 0.0.0.0 --port 8000
+    '';
 
     # Background dev commands
     dev-start.exec = ''
+      ${exportTz}
       mkdir -p .devenv/logs .devenv/pids
       nohup uv run uvicorn puffin.main:app --reload --host 0.0.0.0 --port 8000 > .devenv/logs/dev.log 2>&1 &
       echo $! > .devenv/pids/dev.pid

--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from datetime import UTC, datetime, timedelta
 from datetime import date as date_type
@@ -7,6 +8,11 @@ from sqlalchemy import String, cast, func, select
 from sqlalchemy.orm import Session
 
 from puffin.models import DiaperChange, Feeding, Medication, SavedMedication, TemperatureReading
+
+# "uvicorn.error" is uvicorn's general-purpose app logger, not just errors.
+# Using it makes startup warnings match the surrounding "INFO:" server lines
+# instead of arriving unformatted via logging's last-resort handler.
+logger = logging.getLogger("uvicorn.error")
 
 # --- Generic helpers ---
 
@@ -23,6 +29,31 @@ def _get_local_tz() -> ZoneInfo:
         return ZoneInfo(tz_name)
     except (ZoneInfoNotFoundError, KeyError):
         return ZoneInfo("UTC")
+
+
+def warn_if_tz_unconfigured() -> None:
+    """Log a warning at startup if ``TZ`` is unset or unusable.
+
+    Day boundaries silently fall back to UTC in both cases, which shifts
+    evening activity west of UTC onto the next day. Called from the app
+    lifespan so self-hosters see it in the container logs.
+    """
+    tz_name = os.environ.get("TZ")
+    if tz_name is None:
+        logger.warning(
+            "TZ is not set; day boundaries use UTC. Activity logged in the evening "
+            "west of UTC will count toward tomorrow. Set TZ to an IANA timezone "
+            "name (e.g. TZ=America/New_York)."
+        )
+        return
+    try:
+        ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, KeyError):
+        logger.warning(
+            "TZ=%r is not a recognized IANA timezone name; falling back to UTC. "
+            "Day boundaries will not match your local time.",
+            tz_name,
+        )
 
 
 def _period_count(db: Session, model, timestamp_col, period: str) -> int:

--- a/src/puffin/main.py
+++ b/src/puffin/main.py
@@ -7,6 +7,7 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
 
+from puffin.crud import warn_if_tz_unconfigured
 from puffin.database import init_db
 from puffin.routers import activities, dashboard, diapers, feedings, health
 
@@ -25,6 +26,7 @@ class NoCacheAPIMiddleware(BaseHTTPMiddleware):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    warn_if_tz_unconfigured()
     init_db()
     yield
 


### PR DESCRIPTION
## What

Day boundaries for the dashboard's "today" counts and the day timeline are computed from the `TZ` environment variable, which defaults to UTC. `TZ` was documented only in the `_get_local_tz()` docstring — the README's Environment Variables section listed just `PUFFIN_DB_PATH`, and the `docker run` example didn't pass `TZ`. Self-hosters west of UTC silently got wrong day boundaries.

Reproduced concretely: a diaper logged at 21:10 US Central is stored as 02:10 UTC the following day, so `GET /api/dashboard?date=<local today>` returns 0 until midnight UTC. The same request with `TZ=America/Chicago` returns the correct count.

## Changes

- **README** — documents `TZ` in Environment Variables with the concrete failure mode, and adds `-e TZ=America/New_York` to the `docker run` example.
- **Startup warning** (`warn_if_tz_unconfigured()` in `crud.py`, called from the app lifespan) — warns when `TZ` is unset, and *also* when it's set to a value `ZoneInfo` rejects. The second case matters: the existing `except (ZoneInfoNotFoundError, KeyError)` fallback silently swallows a typo'd zone into UTC, so someone who sets `TZ=America/Chicgao` reproduces the exact bug they were trying to fix with no signal.
- **devenv.nix** — `dev` and `dev-start` now derive `TZ` from the host's `/etc/localtime` symlink when it isn't already set, so local development matches what the browser shows. `test` and `seed` are deliberately left alone; pinning tests to a host-dependent zone would make them non-deterministic across machines.

## Verification

Started the server three times and read the actual log output:

| `TZ` | Result |
|---|---|
| unset | `WARNING:  TZ is not set; day boundaries use UTC…` |
| `America/Chicgao` | `WARNING:  TZ='America/Chicgao' is not a recognized IANA timezone name…` |
| `America/Chicago` | no warning |

All three served `/api/dashboard` 200 afterward. `86 passed`; `ruff check` clean on both changed Python files.

## Notes for the reviewer

- The warning logs to `uvicorn.error` (uvicorn's general-purpose app logger, despite the name) rather than a module logger. With a module logger the line arrived unformatted via logging's last-resort handler — a bare line among uvicorn's `INFO:`-prefixed ones, which reads as less alarming than the `INFO` lines around it. Under pytest, with no uvicorn handler attached, it propagates to root normally.
- **Not addressed here:** deriving day bounds from the client's date instead of server `TZ`. `_day_bounds()` takes a client-supplied `YYYY-MM-DD`, but `_period_count()` — which drives the dashboard summary tiles — computes "today" from `datetime.now(local_tz)` with no client input at all. Interpreting the client date in the browser's zone while leaving `_period_count` on server `TZ` would render the summary tiles and the timeline against two different midnights. Doing it properly means threading a UTC offset through the router surface; that seemed out of scope for a docs/warning fix, but worth a decision.
- `ruff check .` across the whole repo reports 2 pre-existing errors in `src/puffin/routers/health.py` (unsorted imports, unused `DosageUnit`). They're on `main`, unrelated to this change, and left untouched.

Unrelated to child profiles (#44) — the timezone functions are unchanged on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)