### PR TITLE
Add optional child profiles for tracking multiple children

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -6,7 +6,40 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from sqlalchemy import String, cast, func, select
 from sqlalchemy.orm import Session
 
-from puffin.models import DiaperChange, Feeding, Medication, SavedMedication, TemperatureReading
+from puffin.models import (
+    Child,
+    DiaperChange,
+    Feeding,
+    Medication,
+    SavedMedication,
+    TemperatureReading,
+)
+
+# --- Child filtering ---
+
+UNASSIGNED = "unassigned"
+
+# Which logs a query covers:
+#   ``None``          — every log, regardless of child (the zero-profile default)
+#   ``int``           — logs belonging to that child
+#   ``UNASSIGNED``    — logs belonging to no child (``child_id IS NULL``)
+ChildFilter = int | str | None
+
+
+def _child_where(stmt, col, child: ChildFilter):
+    """Narrow *stmt* to the logs *child* covers."""
+    if child is None:
+        return stmt
+    if child == UNASSIGNED:
+        return stmt.where(col.is_(None))
+    return stmt.where(col == child)
+
+
+# Update kwargs whose explicit ``None`` is a real value rather than "not
+# supplied".  Setting ``child_id`` to ``None`` is how a log is deliberately
+# moved back to unassigned, so it must not be skipped like other blanks.
+_NULLABLE_UPDATE_KEYS = {"child_id"}
+
 
 # --- Generic helpers ---
 
@@ -25,7 +58,7 @@ def _get_local_tz() -> ZoneInfo:
         return ZoneInfo("UTC")
 
 
-def _period_count(db: Session, model, timestamp_col, period: str) -> int:
+def _period_count(db: Session, model, timestamp_col, period: str, child: ChildFilter = None) -> int:
     local_tz = _get_local_tz()
     now = datetime.now(local_tz)
     if period == "today":
@@ -38,6 +71,7 @@ def _period_count(db: Session, model, timestamp_col, period: str) -> int:
     else:
         start = now
     stmt = select(func.count()).select_from(model).where(timestamp_col >= start)
+    stmt = _child_where(stmt, model.child_id, child)
     return db.execute(stmt).scalar() or 0
 
 
@@ -45,9 +79,15 @@ def _period_count(db: Session, model, timestamp_col, period: str) -> int:
 
 
 def create_diaper(
-    db: Session, timestamp: datetime | None, type_: str, notes: str | None
+    db: Session,
+    timestamp: datetime | None,
+    type_: str,
+    notes: str | None,
+    child_id: int | None = None,
 ) -> DiaperChange:
-    obj = DiaperChange(timestamp=timestamp or datetime.now(UTC), type=type_, notes=notes)
+    obj = DiaperChange(
+        timestamp=timestamp or datetime.now(UTC), type=type_, notes=notes, child_id=child_id
+    )
     db.add(obj)
     db.commit()
     db.refresh(obj)
@@ -60,12 +100,14 @@ def get_diapers(
     end_date: datetime | None = None,
     limit: int = 50,
     offset: int = 0,
+    child: ChildFilter = None,
 ) -> list[DiaperChange]:
     stmt = select(DiaperChange).order_by(DiaperChange.timestamp.desc())
     if start_date:
         stmt = stmt.where(DiaperChange.timestamp >= start_date)
     if end_date:
         stmt = stmt.where(DiaperChange.timestamp <= end_date)
+    stmt = _child_where(stmt, DiaperChange.child_id, child)
     stmt = stmt.offset(offset).limit(limit)
     return list(db.execute(stmt).scalars().all())
 
@@ -79,7 +121,7 @@ def update_diaper(db: Session, diaper_id: int, **kwargs) -> DiaperChange | None:
     if not obj:
         return None
     for k, v in kwargs.items():
-        if v is not None:
+        if v is not None or k in _NULLABLE_UPDATE_KEYS:
             setattr(obj, k, v)
     db.commit()
     db.refresh(obj)
@@ -95,11 +137,11 @@ def delete_diaper(db: Session, diaper_id: int) -> bool:
     return True
 
 
-def diaper_stats(db: Session) -> dict[str, int]:
+def diaper_stats(db: Session, child: ChildFilter = None) -> dict[str, int]:
     return {
-        "today": _period_count(db, DiaperChange, DiaperChange.timestamp, "today"),
-        "week": _period_count(db, DiaperChange, DiaperChange.timestamp, "week"),
-        "month": _period_count(db, DiaperChange, DiaperChange.timestamp, "month"),
+        "today": _period_count(db, DiaperChange, DiaperChange.timestamp, "today", child),
+        "week": _period_count(db, DiaperChange, DiaperChange.timestamp, "week", child),
+        "month": _period_count(db, DiaperChange, DiaperChange.timestamp, "month", child),
     }
 
 
@@ -124,6 +166,7 @@ def create_feeding(
     notes: str | None,
     session_id: str | None = None,
     bottle_type: str | None = None,
+    child_id: int | None = None,
 ) -> Feeding:
     if feeding_type != "bottle":
         amount = None
@@ -137,6 +180,7 @@ def create_feeding(
         notes=notes,
         session_id=session_id,
         bottle_type=bottle_type,
+        child_id=child_id,
     )
     db.add(obj)
     db.commit()
@@ -150,12 +194,14 @@ def get_feedings(
     end_date: datetime | None = None,
     limit: int = 50,
     offset: int = 0,
+    child: ChildFilter = None,
 ) -> list[Feeding]:
     stmt = select(Feeding).order_by(Feeding.timestamp.desc())
     if start_date:
         stmt = stmt.where(Feeding.timestamp >= start_date)
     if end_date:
         stmt = stmt.where(Feeding.timestamp <= end_date)
+    stmt = _child_where(stmt, Feeding.child_id, child)
     stmt = stmt.offset(offset).limit(limit)
     return list(db.execute(stmt).scalars().all())
 
@@ -173,7 +219,7 @@ def update_feeding(db: Session, feeding_id: int, **kwargs) -> Feeding | None:
         kwargs["amount"] = None
         kwargs["amount_unit"] = None
     for k, v in kwargs.items():
-        if v is not None or k in {"amount", "amount_unit"}:
+        if v is not None or k in {"amount", "amount_unit"} | _NULLABLE_UPDATE_KEYS:
             setattr(obj, k, v)
     db.commit()
     db.refresh(obj)
@@ -189,7 +235,7 @@ def delete_feeding(db: Session, feeding_id: int) -> bool:
     return True
 
 
-def _feeding_session_count(db: Session, start: datetime) -> int:
+def _feeding_session_count(db: Session, start: datetime, child: ChildFilter = None) -> int:
     """Count unique feeding sessions from *start* to now.
 
     Breast feedings that share a ``session_id`` are counted as one session.
@@ -198,26 +244,33 @@ def _feeding_session_count(db: Session, start: datetime) -> int:
     """
     session_key = func.coalesce(Feeding.session_id, cast(Feeding.id, String))
     stmt = select(func.count(func.distinct(session_key))).where(Feeding.timestamp >= start)
+    stmt = _child_where(stmt, Feeding.child_id, child)
     return db.execute(stmt).scalar() or 0
 
 
-def _count_range(db: Session, model, timestamp_col, start: datetime, end: datetime) -> int:
+def _count_range(
+    db: Session, model, timestamp_col, start: datetime, end: datetime, child: ChildFilter = None
+) -> int:
     stmt = (
         select(func.count()).select_from(model).where(timestamp_col >= start, timestamp_col < end)
     )
+    stmt = _child_where(stmt, model.child_id, child)
     return db.execute(stmt).scalar() or 0
 
 
-def _feeding_session_count_range(db: Session, start: datetime, end: datetime) -> int:
+def _feeding_session_count_range(
+    db: Session, start: datetime, end: datetime, child: ChildFilter = None
+) -> int:
     session_key = func.coalesce(Feeding.session_id, cast(Feeding.id, String))
     stmt = select(func.count(func.distinct(session_key))).where(
         Feeding.timestamp >= start,
         Feeding.timestamp < end,
     )
+    stmt = _child_where(stmt, Feeding.child_id, child)
     return db.execute(stmt).scalar() or 0
 
 
-def feeding_stats(db: Session) -> dict[str, int]:
+def feeding_stats(db: Session, child: ChildFilter = None) -> dict[str, int]:
     local_tz = _get_local_tz()
     now = datetime.now(local_tz)
     local_midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -225,9 +278,9 @@ def feeding_stats(db: Session) -> dict[str, int]:
     week_start = (now - timedelta(days=7)).astimezone(UTC)
     month_start = (now - timedelta(days=30)).astimezone(UTC)
     return {
-        "today": _feeding_session_count(db, today_start),
-        "week": _feeding_session_count(db, week_start),
-        "month": _feeding_session_count(db, month_start),
+        "today": _feeding_session_count(db, today_start, child),
+        "week": _feeding_session_count(db, week_start, child),
+        "month": _feeding_session_count(db, month_start, child),
     }
 
 
@@ -241,6 +294,7 @@ def create_medication(
     dosage_quantity: float,
     dosage_unit: str,
     notes: str | None,
+    child_id: int | None = None,
 ) -> Medication:
     obj = Medication(
         timestamp=timestamp or datetime.now(UTC),
@@ -248,6 +302,7 @@ def create_medication(
         dosage_quantity=dosage_quantity,
         dosage_unit=dosage_unit,
         notes=notes,
+        child_id=child_id,
     )
     db.add(obj)
     db.commit()
@@ -261,12 +316,14 @@ def get_medications(
     end_date: datetime | None = None,
     limit: int = 50,
     offset: int = 0,
+    child: ChildFilter = None,
 ) -> list[Medication]:
     stmt = select(Medication).order_by(Medication.timestamp.desc())
     if start_date:
         stmt = stmt.where(Medication.timestamp >= start_date)
     if end_date:
         stmt = stmt.where(Medication.timestamp <= end_date)
+    stmt = _child_where(stmt, Medication.child_id, child)
     stmt = stmt.offset(offset).limit(limit)
     return list(db.execute(stmt).scalars().all())
 
@@ -280,7 +337,7 @@ def update_medication(db: Session, medication_id: int, **kwargs) -> Medication |
     if not obj:
         return None
     for k, v in kwargs.items():
-        if v is not None:
+        if v is not None or k in _NULLABLE_UPDATE_KEYS:
             setattr(obj, k, v)
     db.commit()
     db.refresh(obj)
@@ -296,11 +353,11 @@ def delete_medication(db: Session, medication_id: int) -> bool:
     return True
 
 
-def medication_stats(db: Session) -> dict[str, int]:
+def medication_stats(db: Session, child: ChildFilter = None) -> dict[str, int]:
     return {
-        "today": _period_count(db, Medication, Medication.timestamp, "today"),
-        "week": _period_count(db, Medication, Medication.timestamp, "week"),
-        "month": _period_count(db, Medication, Medication.timestamp, "month"),
+        "today": _period_count(db, Medication, Medication.timestamp, "today", child),
+        "week": _period_count(db, Medication, Medication.timestamp, "week", child),
+        "month": _period_count(db, Medication, Medication.timestamp, "month", child),
     }
 
 
@@ -329,12 +386,14 @@ def create_temperature(
     temperature_celsius: float,
     location: str | None,
     notes: str | None,
+    child_id: int | None = None,
 ) -> TemperatureReading:
     obj = TemperatureReading(
         timestamp=timestamp or datetime.now(UTC),
         temperature_celsius=temperature_celsius,
         location=location,
         notes=notes,
+        child_id=child_id,
     )
     db.add(obj)
     db.commit()
@@ -348,12 +407,14 @@ def get_temperatures(
     end_date: datetime | None = None,
     limit: int = 50,
     offset: int = 0,
+    child: ChildFilter = None,
 ) -> list[TemperatureReading]:
     stmt = select(TemperatureReading).order_by(TemperatureReading.timestamp.desc())
     if start_date:
         stmt = stmt.where(TemperatureReading.timestamp >= start_date)
     if end_date:
         stmt = stmt.where(TemperatureReading.timestamp <= end_date)
+    stmt = _child_where(stmt, TemperatureReading.child_id, child)
     stmt = stmt.offset(offset).limit(limit)
     return list(db.execute(stmt).scalars().all())
 
@@ -367,7 +428,7 @@ def update_temperature(db: Session, temp_id: int, **kwargs) -> TemperatureReadin
     if not obj:
         return None
     for k, v in kwargs.items():
-        if v is not None:
+        if v is not None or k in _NULLABLE_UPDATE_KEYS:
             setattr(obj, k, v)
     db.commit()
     db.refresh(obj)
@@ -381,6 +442,88 @@ def delete_temperature(db: Session, temp_id: int) -> bool:
     db.delete(obj)
     db.commit()
     return True
+
+
+# --- Children ---
+
+_LOG_MODELS = (DiaperChange, Feeding, Medication, TemperatureReading)
+
+
+def create_child(db: Session, name: str) -> Child:
+    obj = Child(name=name)
+    db.add(obj)
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+def get_children(db: Session) -> list[Child]:
+    """Return profiles oldest-first.
+
+    Creation order is the switcher's display order, and the first profile
+    created is the default selection.
+    """
+    stmt = select(Child).order_by(Child.created_at.asc(), Child.id.asc())
+    return list(db.execute(stmt).scalars().all())
+
+
+def get_child(db: Session, child_id: int) -> Child | None:
+    return db.get(Child, child_id)
+
+
+def update_child(db: Session, child_id: int, name: str) -> Child | None:
+    obj = db.get(Child, child_id)
+    if not obj:
+        return None
+    obj.name = name
+    db.commit()
+    db.refresh(obj)
+    return obj
+
+
+def delete_child(db: Session, child_id: int) -> bool:
+    """Delete a profile, returning its logs to unassigned.
+
+    Deleting a profile never deletes logs — they keep every field except the
+    association, and resurface under the unassigned view where they can be
+    re-assigned individually or in bulk.
+    """
+    obj = db.get(Child, child_id)
+    if not obj:
+        return False
+    for model in _LOG_MODELS:
+        db.query(model).filter(model.child_id == child_id).update(
+            {"child_id": None}, synchronize_session=False
+        )
+    db.delete(obj)
+    db.commit()
+    return True
+
+
+def count_unassigned_logs(db: Session) -> int:
+    """Total logs across all types belonging to no profile."""
+    total = 0
+    for model in _LOG_MODELS:
+        stmt = select(func.count()).select_from(model).where(model.child_id.is_(None))
+        total += db.execute(stmt).scalar() or 0
+    return total
+
+
+def assign_unassigned_logs(db: Session, child_id: int) -> int:
+    """Move every unassigned log to *child_id*, returning how many moved.
+
+    Backs both the one-time offer at first profile creation and the bulk
+    re-assign available from the unassigned view thereafter.
+    """
+    assigned = 0
+    for model in _LOG_MODELS:
+        assigned += (
+            db.query(model)
+            .filter(model.child_id.is_(None))
+            .update({"child_id": child_id}, synchronize_session=False)
+        )
+    db.commit()
+    return assigned
 
 
 # --- Activities ---
@@ -424,10 +567,10 @@ def _day_bounds(date_str: str) -> tuple[datetime, datetime]:
     return start, end
 
 
-def get_activities_for_date(db: Session, date_str: str) -> list[dict]:
+def get_activities_for_date(db: Session, date_str: str, child: ChildFilter = None) -> list[dict]:
     """Return activities for a local calendar date (YYYY-MM-DD)."""
     start, end = _day_bounds(date_str)
-    return get_activities(db, start=start, end=end)
+    return get_activities(db, start=start, end=end, child=child)
 
 
 def get_activities(
@@ -435,11 +578,12 @@ def get_activities(
     start: datetime,
     end: datetime,
     limit: int = 200,
+    child: ChildFilter = None,
 ) -> list[dict]:
     """Return a merged, sorted list of all activity types in a time range."""
     activities: list[dict] = []
 
-    for d in get_diapers(db, start_date=start, end_date=end, limit=limit):
+    for d in get_diapers(db, start_date=start, end_date=end, limit=limit, child=child):
         activities.append(
             {
                 "type": "diaper",
@@ -453,7 +597,7 @@ def get_activities(
                 "notes": d.notes,
             }
         )
-    feedings = get_feedings(db, start_date=start, end_date=end, limit=limit)
+    feedings = get_feedings(db, start_date=start, end_date=end, limit=limit, child=child)
 
     # Separate individually-logged feedings from paired (session_id) ones
     session_groups: dict[str, list] = {}
@@ -509,7 +653,7 @@ def get_activities(
                 "notes": notes,
             }
         )
-    for m in get_medications(db, start_date=start, end_date=end, limit=limit):
+    for m in get_medications(db, start_date=start, end_date=end, limit=limit, child=child):
         activities.append(
             {
                 "type": "medication",
@@ -523,7 +667,7 @@ def get_activities(
                 "notes": m.notes,
             }
         )
-    for t in get_temperatures(db, start_date=start, end_date=end, limit=limit):
+    for t in get_temperatures(db, start_date=start, end_date=end, limit=limit, child=child):
         temp_f = round(t.temperature_celsius * 9 / 5 + 32, 1)
         activities.append(
             {
@@ -546,34 +690,33 @@ def get_activities(
 # --- Dashboard ---
 
 
-def get_dashboard(db: Session, date_str: str | None = None) -> dict:
+def get_dashboard(db: Session, date_str: str | None = None, child: ChildFilter = None) -> dict:
     now = datetime.now(UTC)
 
     # Stats
-    d_stats = diaper_stats(db)
-    f_stats = feeding_stats(db)
-    med_today = _period_count(db, Medication, Medication.timestamp, "today")
+    d_stats = diaper_stats(db, child)
+    f_stats = feeding_stats(db, child)
+    med_today = _period_count(db, Medication, Medication.timestamp, "today", child)
 
     if date_str:
         start, end = _day_bounds(date_str)
-        d_stats["today"] = _count_range(db, DiaperChange, DiaperChange.timestamp, start, end)
-        f_stats["today"] = _feeding_session_count_range(db, start, end)
-        med_today = _count_range(db, Medication, Medication.timestamp, start, end)
+        d_stats["today"] = _count_range(db, DiaperChange, DiaperChange.timestamp, start, end, child)
+        f_stats["today"] = _feeding_session_count_range(db, start, end, child)
+        med_today = _count_range(db, Medication, Medication.timestamp, start, end, child)
 
-    # Last entries
-    last_diaper = db.execute(
-        select(DiaperChange).order_by(DiaperChange.timestamp.desc()).limit(1)
-    ).scalar_one_or_none()
-    last_feeding = db.execute(
-        select(Feeding).order_by(Feeding.timestamp.desc()).limit(1)
-    ).scalar_one_or_none()
-    last_temp = db.execute(
-        select(TemperatureReading).order_by(TemperatureReading.timestamp.desc()).limit(1)
-    ).scalar_one_or_none()
+    # Last entries — scoped to the same child as the counts, so "last fed 2h
+    # ago" never reports another child's feeding.
+    def _latest(model):
+        stmt = select(model).order_by(model.timestamp.desc()).limit(1)
+        return db.execute(_child_where(stmt, model.child_id, child)).scalar_one_or_none()
+
+    last_diaper = _latest(DiaperChange)
+    last_feeding = _latest(Feeding)
+    last_temp = _latest(TemperatureReading)
 
     # Recent activities (last 3 days, excluding future)
     three_days_ago = now - timedelta(days=3)
-    activities = get_activities(db, start=three_days_ago, end=now)
+    activities = get_activities(db, start=three_days_ago, end=now, child=child)
 
     return {
         "diaper_stats": d_stats,

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -146,6 +146,27 @@ def _run_migrations(bind=None) -> None:
             conn.execute(text("PRAGMA foreign_keys=on"))
             conn.commit()
 
+        # Child profiles: every log table gains a nullable ``child_id``.
+        # Existing rows keep ``NULL`` (unassigned) — no log data is read or
+        # reinterpreted here.  Bulk assignment to a profile is a separate,
+        # user-initiated action.  This must run after the ``feedings`` rebuild
+        # above (which recreates the table without ``child_id``) and before the
+        # medications early-return below.
+        insp = inspect(conn)
+        for table, index in (
+            ("diaper_changes", "idx_diaper_child"),
+            ("feedings", "idx_feeding_child"),
+            ("medications", "idx_medication_child"),
+            ("temperature_readings", "idx_temperature_child"),
+        ):
+            if not insp.has_table(table):
+                continue
+            if "child_id" not in {c["name"] for c in insp.get_columns(table)}:
+                conn.execute(text(f"ALTER TABLE {table} ADD COLUMN child_id INTEGER"))
+                conn.commit()
+            conn.execute(text(f"CREATE INDEX IF NOT EXISTS {index} ON {table} (child_id)"))
+            conn.commit()
+
         insp = inspect(conn)
         if not insp.has_table("medications"):
             return

--- a/src/puffin/dependencies.py
+++ b/src/puffin/dependencies.py
@@ -1,0 +1,18 @@
+from fastapi import Query
+
+from puffin.crud import UNASSIGNED, ChildFilter
+
+
+def child_filter(
+    child_id: int | None = Query(None, description="Only include logs for this child"),
+    unassigned: bool = Query(False, description="Only include logs belonging to no child"),
+) -> ChildFilter:
+    """Resolve the child scope of a request.
+
+    Omitting both parameters means *every* log regardless of child, which is
+    what an install with no profiles always sees.  ``unassigned`` wins over
+    ``child_id`` so the two can never be combined into an impossible filter.
+    """
+    if unassigned:
+        return UNASSIGNED
+    return child_id

--- a/src/puffin/main.py
+++ b/src/puffin/main.py
@@ -8,7 +8,7 @@ from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
 
 from puffin.database import init_db
-from puffin.routers import activities, dashboard, diapers, feedings, health
+from puffin.routers import activities, children, dashboard, diapers, feedings, health
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -46,6 +46,7 @@ templates = Jinja2Templates(directory=str(BASE_DIR / "templates"))
 
 # Include routers
 app.include_router(activities.router)
+app.include_router(children.router)
 app.include_router(diapers.router)
 app.include_router(feedings.router)
 app.include_router(health.router)

--- a/src/puffin/models.py
+++ b/src/puffin/models.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 
-from sqlalchemy import DateTime, Float, Index, Integer, String, Text
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String, Text
 from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.types import TypeDecorator
 
@@ -30,6 +30,30 @@ def _utcnow() -> datetime:
     return datetime.now(UTC)
 
 
+class Child(Base):
+    """An optional profile a log can be associated with.
+
+    Profiles are opt-in: an install with no rows here behaves exactly as
+    Puffin did before profiles existed.
+    """
+
+    __tablename__ = "children"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(_TZ_DATETIME, default=_utcnow)
+
+
+def _child_fk() -> Mapped[int | None]:
+    """A nullable association to a :class:`Child`.
+
+    ``NULL`` means *unassigned* — the state of every log predating profiles,
+    of logs whose profile was deleted, and of logs explicitly set back to
+    unassigned by editing them.
+    """
+    return mapped_column(Integer, ForeignKey("children.id", ondelete="SET NULL"), nullable=True)
+
+
 class DiaperChange(Base):
     __tablename__ = "diaper_changes"
 
@@ -37,9 +61,13 @@ class DiaperChange(Base):
     timestamp: Mapped[datetime] = mapped_column(_TZ_DATETIME, nullable=False, default=_utcnow)
     type: Mapped[str] = mapped_column(String, nullable=False)  # pee, poop, both
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    child_id: Mapped[int | None] = _child_fk()
     created_at: Mapped[datetime] = mapped_column(_TZ_DATETIME, default=_utcnow)
 
-    __table_args__ = (Index("idx_diaper_timestamp", "timestamp"),)
+    __table_args__ = (
+        Index("idx_diaper_timestamp", "timestamp"),
+        Index("idx_diaper_child", "child_id"),
+    )
 
 
 class Feeding(Base):
@@ -56,9 +84,13 @@ class Feeding(Base):
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
     session_id: Mapped[str | None] = mapped_column(String, nullable=True)
     bottle_type: Mapped[str | None] = mapped_column(String, nullable=True)  # breastmilk, formula
+    child_id: Mapped[int | None] = _child_fk()
     created_at: Mapped[datetime] = mapped_column(_TZ_DATETIME, default=_utcnow)
 
-    __table_args__ = (Index("idx_feeding_timestamp", "timestamp"),)
+    __table_args__ = (
+        Index("idx_feeding_timestamp", "timestamp"),
+        Index("idx_feeding_child", "child_id"),
+    )
 
 
 class Medication(Base):
@@ -70,9 +102,13 @@ class Medication(Base):
     dosage_quantity: Mapped[float] = mapped_column(Float, nullable=False)
     dosage_unit: Mapped[str] = mapped_column(String, nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    child_id: Mapped[int | None] = _child_fk()
     created_at: Mapped[datetime] = mapped_column(_TZ_DATETIME, default=_utcnow)
 
-    __table_args__ = (Index("idx_medication_timestamp", "timestamp"),)
+    __table_args__ = (
+        Index("idx_medication_timestamp", "timestamp"),
+        Index("idx_medication_child", "child_id"),
+    )
 
 
 class TemperatureReading(Base):
@@ -85,9 +121,13 @@ class TemperatureReading(Base):
         String, nullable=True
     )  # rectal, oral, axillary, temporal
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    child_id: Mapped[int | None] = _child_fk()
     created_at: Mapped[datetime] = mapped_column(_TZ_DATETIME, default=_utcnow)
 
-    __table_args__ = (Index("idx_temperature_timestamp", "timestamp"),)
+    __table_args__ = (
+        Index("idx_temperature_timestamp", "timestamp"),
+        Index("idx_temperature_child", "child_id"),
+    )
 
 
 class SavedMedication(Base):

--- a/src/puffin/routers/activities.py
+++ b/src/puffin/routers/activities.py
@@ -2,7 +2,9 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.orm import Session
 
 from puffin import crud
+from puffin.crud import ChildFilter
 from puffin.database import get_db
+from puffin.dependencies import child_filter
 from puffin.schemas import ActivityItem
 
 router = APIRouter(prefix="/api/activities", tags=["activities"])
@@ -11,6 +13,7 @@ router = APIRouter(prefix="/api/activities", tags=["activities"])
 @router.get("", response_model=list[ActivityItem])
 def list_activities(
     date: str = Query(..., description="Local date as YYYY-MM-DD", pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    child: ChildFilter = Depends(child_filter),
     db: Session = Depends(get_db),
 ):
-    return crud.get_activities_for_date(db, date_str=date)
+    return crud.get_activities_for_date(db, date_str=date, child=child)

--- a/src/puffin/routers/children.py
+++ b/src/puffin/routers/children.py
@@ -1,0 +1,71 @@
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from puffin import crud
+from puffin.database import get_db
+from puffin.schemas import (
+    BulkAssignResult,
+    ChildCreate,
+    ChildResponse,
+    ChildUpdate,
+    UnassignedSummary,
+)
+
+router = APIRouter(prefix="/api/children", tags=["children"])
+
+
+@router.get("", response_model=list[ChildResponse])
+def list_children(db: Session = Depends(get_db)):
+    return crud.get_children(db)
+
+
+@router.post("", response_model=ChildResponse, status_code=201)
+def create_child(data: ChildCreate, db: Session = Depends(get_db)):
+    return crud.create_child(db, name=data.name)
+
+
+@router.get("/unassigned", response_model=UnassignedSummary)
+def get_unassigned_summary(db: Session = Depends(get_db)):
+    """How many logs belong to no profile.
+
+    Drives the conditional ``Unassigned logs`` switcher option, and tells the
+    client whether the one-time migration offer applies at first profile
+    creation.  Declared before ``/{child_id}`` so it is not shadowed by it.
+    """
+    return {"count": crud.count_unassigned_logs(db)}
+
+
+@router.get("/{child_id}", response_model=ChildResponse)
+def get_child(child_id: int, db: Session = Depends(get_db)):
+    obj = crud.get_child(db, child_id)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Child not found")
+    return obj
+
+
+@router.put("/{child_id}", response_model=ChildResponse)
+def update_child(child_id: int, data: ChildUpdate, db: Session = Depends(get_db)):
+    obj = crud.update_child(db, child_id, name=data.name)
+    if not obj:
+        raise HTTPException(status_code=404, detail="Child not found")
+    return obj
+
+
+@router.delete("/{child_id}", status_code=204)
+def delete_child(child_id: int, db: Session = Depends(get_db)):
+    """Delete a profile. Its logs are kept and returned to unassigned."""
+    if not crud.delete_child(db, child_id):
+        raise HTTPException(status_code=404, detail="Child not found")
+
+
+@router.post("/{child_id}/assign-unassigned", response_model=BulkAssignResult)
+def assign_unassigned(child_id: int, db: Session = Depends(get_db)):
+    """Move every unassigned log to this profile.
+
+    Used both by the one-time offer at first profile creation and by the bulk
+    re-assign in the unassigned view.  The two-step confirmation guarding this
+    is a client concern; the endpoint itself is a single idempotent-ish sweep.
+    """
+    if not crud.get_child(db, child_id):
+        raise HTTPException(status_code=404, detail="Child not found")
+    return {"assigned": crud.assign_unassigned_logs(db, child_id)}

--- a/src/puffin/routers/dashboard.py
+++ b/src/puffin/routers/dashboard.py
@@ -8,12 +8,16 @@ from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 
 from puffin import crud
+from puffin.crud import ChildFilter
 from puffin.database import get_db
+from puffin.dependencies import child_filter
 from puffin.schemas import DashboardSummary
 
 router = APIRouter(prefix="/api", tags=["dashboard"])
 
 _PDF_MAX_CELL_LENGTH = 40  # max characters per cell before truncation
+
+_UNASSIGNED_LABEL = "Unassigned"
 
 
 def _format_bottle_amount(amount: float | None, amount_unit: str | None) -> str:
@@ -27,9 +31,10 @@ def _format_bottle_amount(amount: float | None, amount_unit: str | None) -> str:
 @router.get("/dashboard", response_model=DashboardSummary)
 def get_dashboard(
     date: str | None = Query(None, pattern=r"^\d{4}-\d{2}-\d{2}$"),
+    child: ChildFilter = Depends(child_filter),
     db: Session = Depends(get_db),
 ):
-    return crud.get_dashboard(db, date_str=date)
+    return crud.get_dashboard(db, date_str=date, child=child)
 
 
 @router.get("/export")
@@ -37,12 +42,30 @@ def export_data(
     export_format: str = Query("csv", alias="format", pattern="^(csv|json|pdf)$"),
     start_date: datetime | None = Query(None),
     end_date: datetime | None = Query(None),
+    child: ChildFilter = Depends(child_filter),
     db: Session = Depends(get_db),
 ):
-    diapers = crud.get_diapers(db, start_date=start_date, end_date=end_date, limit=10000)
-    feedings = crud.get_feedings(db, start_date=start_date, end_date=end_date, limit=10000)
-    medications = crud.get_medications(db, start_date=start_date, end_date=end_date, limit=10000)
-    temperatures = crud.get_temperatures(db, start_date=start_date, end_date=end_date, limit=10000)
+    diapers = crud.get_diapers(
+        db, start_date=start_date, end_date=end_date, limit=10000, child=child
+    )
+    feedings = crud.get_feedings(
+        db, start_date=start_date, end_date=end_date, limit=10000, child=child
+    )
+    medications = crud.get_medications(
+        db, start_date=start_date, end_date=end_date, limit=10000, child=child
+    )
+    temperatures = crud.get_temperatures(
+        db, start_date=start_date, end_date=end_date, limit=10000, child=child
+    )
+
+    # A child column only earns its place when the export spans more than one
+    # child.  Scoped exports are already about a single child, and installs
+    # with no profiles would just get a blank column.
+    child_names = {c.id: c.name for c in crud.get_children(db)}
+    include_child = child is None and bool(child_names)
+
+    def child_name(obj) -> str:
+        return child_names.get(obj.child_id, _UNASSIGNED_LABEL)
 
     if export_format == "json":
         from puffin.schemas import (
@@ -66,6 +89,10 @@ def export_data(
                 TemperatureResponse.model_validate(t).model_dump(mode="json") for t in temperatures
             ],
         }
+        if include_child:
+            # Records carry ``child_id``; this resolves those ids to names
+            # without repeating the name on every row.
+            data["children"] = {str(cid): name for cid, name in child_names.items()}
         content = json.dumps(data, indent=2, default=str)
         return StreamingResponse(
             io.BytesIO(content.encode()),
@@ -96,64 +123,84 @@ def export_data(
         pdf.set_auto_page_break(auto=True, margin=15)
         pdf.add_page()
 
+        def with_child(headers: list[str], rows: list[list[str]], objs) -> tuple:
+            """Append a trailing Child column when the export spans children."""
+            if not include_child:
+                return headers, rows
+            return headers + ["Child"], [
+                row + [child_name(obj)] for row, obj in zip(rows, objs, strict=True)
+            ]
+
         _pdf_section(
             pdf,
             "Diaper Changes",
-            ["Time", "Type", "Notes"],
-            [
+            *with_child(
+                ["Time", "Type", "Notes"],
                 [
-                    _fmt_ts(d.timestamp),
-                    str(d.type),
-                    d.notes or "",
-                ]
-                for d in diapers
-            ],
+                    [
+                        _fmt_ts(d.timestamp),
+                        str(d.type),
+                        d.notes or "",
+                    ]
+                    for d in diapers
+                ],
+                diapers,
+            ),
         )
 
         _pdf_section(
             pdf,
             "Feedings",
-            ["Time", "Type", "Duration (min)", "Amount", "Notes"],
-            [
+            *with_child(
+                ["Time", "Type", "Duration (min)", "Amount", "Notes"],
                 [
-                    _fmt_ts(f.timestamp),
-                    str(f.feeding_type),
-                    str(f.duration_minutes) if f.duration_minutes is not None else "",
-                    _format_bottle_amount(f.amount, f.amount_unit),
-                    f.notes or "",
-                ]
-                for f in feedings
-            ],
+                    [
+                        _fmt_ts(f.timestamp),
+                        str(f.feeding_type),
+                        str(f.duration_minutes) if f.duration_minutes is not None else "",
+                        _format_bottle_amount(f.amount, f.amount_unit),
+                        f.notes or "",
+                    ]
+                    for f in feedings
+                ],
+                feedings,
+            ),
         )
 
         _pdf_section(
             pdf,
             "Medications",
-            ["Time", "Medication", "Dosage", "Notes"],
-            [
+            *with_child(
+                ["Time", "Medication", "Dosage", "Notes"],
                 [
-                    _fmt_ts(m.timestamp),
-                    m.medication_name,
-                    f"{m.dosage_quantity:.2f} {m.dosage_unit}",
-                    m.notes or "",
-                ]
-                for m in medications
-            ],
+                    [
+                        _fmt_ts(m.timestamp),
+                        m.medication_name,
+                        f"{m.dosage_quantity:.2f} {m.dosage_unit}",
+                        m.notes or "",
+                    ]
+                    for m in medications
+                ],
+                medications,
+            ),
         )
 
         _pdf_section(
             pdf,
             "Temperature Readings",
-            ["Time", "Temp (°C)", "Location", "Notes"],
-            [
+            *with_child(
+                ["Time", "Temp (°C)", "Location", "Notes"],
                 [
-                    _fmt_ts(t.timestamp),
-                    str(t.temperature_celsius),
-                    str(t.location) if t.location else "",
-                    t.notes or "",
-                ]
-                for t in temperatures
-            ],
+                    [
+                        _fmt_ts(t.timestamp),
+                        str(t.temperature_celsius),
+                        str(t.location) if t.location else "",
+                        t.notes or "",
+                    ]
+                    for t in temperatures
+                ],
+                temperatures,
+            ),
         )
 
         pdf_bytes = pdf.output()
@@ -167,71 +214,89 @@ def export_data(
     output = io.StringIO()
     writer = csv.writer(output)
 
+    def header(cols: list[str]) -> list[str]:
+        return cols + ["child"] if include_child else cols
+
+    def row(cells: list, obj) -> list:
+        return cells + [child_name(obj)] if include_child else cells
+
     writer.writerow(["--- Diaper Changes ---"])
-    writer.writerow(["id", "timestamp", "type", "notes", "created_at"])
+    writer.writerow(header(["id", "timestamp", "type", "notes", "created_at"]))
     for d in diapers:
-        writer.writerow([d.id, d.timestamp, d.type, d.notes, d.created_at])
+        writer.writerow(row([d.id, d.timestamp, d.type, d.notes, d.created_at], d))
 
     writer.writerow([])
     writer.writerow(["--- Feedings ---"])
     writer.writerow(
-        [
-            "id",
-            "timestamp",
-            "feeding_type",
-            "duration_minutes",
-            "amount",
-            "amount_unit",
-            "notes",
-            "created_at",
-        ]
+        header(
+            [
+                "id",
+                "timestamp",
+                "feeding_type",
+                "duration_minutes",
+                "amount",
+                "amount_unit",
+                "notes",
+                "created_at",
+            ]
+        )
     )
     for f in feedings:
         writer.writerow(
-            [
-                f.id,
-                f.timestamp,
-                f.feeding_type,
-                f.duration_minutes,
-                f.amount,
-                f.amount_unit,
-                f.notes,
-                f.created_at,
-            ]
+            row(
+                [
+                    f.id,
+                    f.timestamp,
+                    f.feeding_type,
+                    f.duration_minutes,
+                    f.amount,
+                    f.amount_unit,
+                    f.notes,
+                    f.created_at,
+                ],
+                f,
+            )
         )
 
     writer.writerow([])
     writer.writerow(["--- Medications ---"])
     writer.writerow(
-        [
-            "id",
-            "timestamp",
-            "medication_name",
-            "dosage_quantity",
-            "dosage_unit",
-            "notes",
-            "created_at",
-        ]
+        header(
+            [
+                "id",
+                "timestamp",
+                "medication_name",
+                "dosage_quantity",
+                "dosage_unit",
+                "notes",
+                "created_at",
+            ]
+        )
     )
     for m in medications:
         writer.writerow(
-            [
-                m.id,
-                m.timestamp,
-                m.medication_name,
-                m.dosage_quantity,
-                m.dosage_unit,
-                m.notes,
-                m.created_at,
-            ]
+            row(
+                [
+                    m.id,
+                    m.timestamp,
+                    m.medication_name,
+                    m.dosage_quantity,
+                    m.dosage_unit,
+                    m.notes,
+                    m.created_at,
+                ],
+                m,
+            )
         )
 
     writer.writerow([])
     writer.writerow(["--- Temperature Readings ---"])
-    writer.writerow(["id", "timestamp", "temperature_celsius", "location", "notes", "created_at"])
+    writer.writerow(
+        header(["id", "timestamp", "temperature_celsius", "location", "notes", "created_at"])
+    )
     for t in temperatures:
         writer.writerow(
-            [t.id, t.timestamp, t.temperature_celsius, t.location, t.notes, t.created_at]
+            row([t.id, t.timestamp, t.temperature_celsius, t.location, t.notes, t.created_at], t)
         )
 
     content = output.getvalue()

--- a/src/puffin/routers/diapers.py
+++ b/src/puffin/routers/diapers.py
@@ -4,7 +4,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from puffin import crud
+from puffin.crud import ChildFilter
 from puffin.database import get_db
+from puffin.dependencies import child_filter
 from puffin.schemas import DiaperChangeCreate, DiaperChangeResponse, DiaperChangeUpdate, PeriodStats
 
 router = APIRouter(prefix="/api/diapers", tags=["diapers"])
@@ -12,7 +14,13 @@ router = APIRouter(prefix="/api/diapers", tags=["diapers"])
 
 @router.post("", response_model=DiaperChangeResponse, status_code=201)
 def create_diaper(data: DiaperChangeCreate, db: Session = Depends(get_db)):
-    return crud.create_diaper(db, timestamp=data.timestamp, type_=data.type.value, notes=data.notes)
+    return crud.create_diaper(
+        db,
+        timestamp=data.timestamp,
+        type_=data.type.value,
+        notes=data.notes,
+        child_id=data.child_id,
+    )
 
 
 @router.get("", response_model=list[DiaperChangeResponse])
@@ -21,16 +29,20 @@ def list_diapers(
     end_date: datetime | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
+    child: ChildFilter = Depends(child_filter),
     db: Session = Depends(get_db),
 ):
     return crud.get_diapers(
-        db, start_date=start_date, end_date=end_date, limit=limit, offset=offset
+        db, start_date=start_date, end_date=end_date, limit=limit, offset=offset, child=child
     )
 
 
 @router.get("/stats", response_model=PeriodStats)
-def get_diaper_stats(db: Session = Depends(get_db)):
-    return crud.diaper_stats(db)
+def get_diaper_stats(
+    child: ChildFilter = Depends(child_filter),
+    db: Session = Depends(get_db),
+):
+    return crud.diaper_stats(db, child)
 
 
 @router.get("/{diaper_id}", response_model=DiaperChangeResponse)
@@ -50,6 +62,10 @@ def update_diaper(diaper_id: int, data: DiaperChangeUpdate, db: Session = Depend
         updates["type"] = data.type.value
     if data.notes is not None:
         updates["notes"] = data.notes
+    # ``child_id`` keys off fields_set, not None: an explicit null is how a log
+    # is moved back to unassigned.
+    if "child_id" in data.model_fields_set:
+        updates["child_id"] = data.child_id
     obj = crud.update_diaper(db, diaper_id, **updates)
     if not obj:
         raise HTTPException(status_code=404, detail="Diaper change not found")

--- a/src/puffin/routers/feedings.py
+++ b/src/puffin/routers/feedings.py
@@ -4,7 +4,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from puffin import crud
+from puffin.crud import ChildFilter
 from puffin.database import get_db
+from puffin.dependencies import child_filter
 from puffin.schemas import FeedingCreate, FeedingResponse, FeedingUpdate, PeriodStats
 
 router = APIRouter(prefix="/api/feedings", tags=["feedings"])
@@ -22,6 +24,7 @@ def create_feeding(data: FeedingCreate, db: Session = Depends(get_db)):
         notes=data.notes,
         session_id=data.session_id,
         bottle_type=data.bottle_type.value if data.bottle_type else None,
+        child_id=data.child_id,
     )
 
 
@@ -31,16 +34,20 @@ def list_feedings(
     end_date: datetime | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
+    child: ChildFilter = Depends(child_filter),
     db: Session = Depends(get_db),
 ):
     return crud.get_feedings(
-        db, start_date=start_date, end_date=end_date, limit=limit, offset=offset
+        db, start_date=start_date, end_date=end_date, limit=limit, offset=offset, child=child
     )
 
 
 @router.get("/stats", response_model=PeriodStats)
-def get_feeding_stats(db: Session = Depends(get_db)):
-    return crud.feeding_stats(db)
+def get_feeding_stats(
+    child: ChildFilter = Depends(child_filter),
+    db: Session = Depends(get_db),
+):
+    return crud.feeding_stats(db, child)
 
 
 @router.get("/{feeding_id}", response_model=FeedingResponse)
@@ -77,6 +84,10 @@ def update_feeding(feeding_id: int, data: FeedingUpdate, db: Session = Depends(g
         updates["notes"] = data.notes
     if data.bottle_type is not None:
         updates["bottle_type"] = data.bottle_type.value
+    # ``child_id`` keys off fields_set, not None: an explicit null is how a log
+    # is moved back to unassigned.
+    if "child_id" in data.model_fields_set:
+        updates["child_id"] = data.child_id
     return crud.update_feeding(db, feeding_id, **updates)
 
 

--- a/src/puffin/routers/health.py
+++ b/src/puffin/routers/health.py
@@ -4,7 +4,9 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.orm import Session
 
 from puffin import crud
+from puffin.crud import ChildFilter
 from puffin.database import get_db
+from puffin.dependencies import child_filter
 from puffin.schemas import (
     MedicationCreate,
     MedicationResponse,
@@ -13,7 +15,6 @@ from puffin.schemas import (
     TemperatureCreate,
     TemperatureResponse,
     TemperatureUpdate,
-    DosageUnit,
 )
 
 router = APIRouter(tags=["health"])
@@ -31,6 +32,7 @@ def create_medication(data: MedicationCreate, db: Session = Depends(get_db)):
         dosage_quantity=data.dosage_quantity,
         dosage_unit=data.dosage_unit.value,
         notes=data.notes,
+        child_id=data.child_id,
     )
     crud.add_saved_medication(db, data.medication_name)
     return result
@@ -47,16 +49,20 @@ def list_medications(
     end_date: datetime | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
+    child: ChildFilter = Depends(child_filter),
     db: Session = Depends(get_db),
 ):
     return crud.get_medications(
-        db, start_date=start_date, end_date=end_date, limit=limit, offset=offset
+        db, start_date=start_date, end_date=end_date, limit=limit, offset=offset, child=child
     )
 
 
 @router.get("/api/medications/stats", response_model=PeriodStats)
-def get_medication_stats(db: Session = Depends(get_db)):
-    return crud.medication_stats(db)
+def get_medication_stats(
+    child: ChildFilter = Depends(child_filter),
+    db: Session = Depends(get_db),
+):
+    return crud.medication_stats(db, child)
 
 
 @router.get("/api/medications/{medication_id}", response_model=MedicationResponse)
@@ -80,6 +86,10 @@ def update_medication(medication_id: int, data: MedicationUpdate, db: Session = 
         updates["dosage_unit"] = data.dosage_unit.value
     if data.notes is not None:
         updates["notes"] = data.notes
+    # ``child_id`` keys off fields_set, not None: an explicit null is how a log
+    # is moved back to unassigned.
+    if "child_id" in data.model_fields_set:
+        updates["child_id"] = data.child_id
     obj = crud.update_medication(db, medication_id, **updates)
     if not obj:
         raise HTTPException(status_code=404, detail="Medication record not found")
@@ -103,6 +113,7 @@ def create_temperature(data: TemperatureCreate, db: Session = Depends(get_db)):
         temperature_celsius=data.temperature_celsius,
         location=data.location.value if data.location else None,
         notes=data.notes,
+        child_id=data.child_id,
     )
 
 
@@ -112,10 +123,11 @@ def list_temperatures(
     end_date: datetime | None = Query(None),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
+    child: ChildFilter = Depends(child_filter),
     db: Session = Depends(get_db),
 ):
     return crud.get_temperatures(
-        db, start_date=start_date, end_date=end_date, limit=limit, offset=offset
+        db, start_date=start_date, end_date=end_date, limit=limit, offset=offset, child=child
     )
 
 
@@ -138,6 +150,10 @@ def update_temperature(temp_id: int, data: TemperatureUpdate, db: Session = Depe
         updates["location"] = data.location.value
     if data.notes is not None:
         updates["notes"] = data.notes
+    # ``child_id`` keys off fields_set, not None: an explicit null is how a log
+    # is moved back to unassigned.
+    if "child_id" in data.model_fields_set:
+        updates["child_id"] = data.child_id
     obj = crud.update_temperature(db, temp_id, **updates)
     if not obj:
         raise HTTPException(status_code=404, detail="Temperature reading not found")

--- a/src/puffin/schemas.py
+++ b/src/puffin/schemas.py
@@ -48,6 +48,55 @@ class DosageUnit(StrEnum):
     unit = "unit(s)"
 
 
+# --- Child Schemas ---
+
+
+class ChildCreate(BaseModel):
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def check_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Name is required")
+        return v
+
+
+class ChildUpdate(BaseModel):
+    name: str
+
+    @field_validator("name")
+    @classmethod
+    def check_name(cls, v: str) -> str:
+        v = v.strip()
+        if not v:
+            raise ValueError("Name is required")
+        return v
+
+
+class ChildResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    name: str
+    created_at: datetime
+
+
+class UnassignedSummary(BaseModel):
+    """Whether any logs are currently unassigned.
+
+    Drives both the conditional ``Unassigned logs`` switcher option and the
+    one-time migration offer at first profile creation.
+    """
+
+    count: int = 0
+
+
+class BulkAssignResult(BaseModel):
+    assigned: int = 0
+
+
 # --- Diaper Schemas ---
 
 
@@ -55,12 +104,14 @@ class DiaperChangeCreate(BaseModel):
     timestamp: datetime | None = None
     type: DiaperType
     notes: str | None = None
+    child_id: int | None = None
 
 
 class DiaperChangeUpdate(BaseModel):
     timestamp: datetime | None = None
     type: DiaperType | None = None
     notes: str | None = None
+    child_id: int | None = None
 
 
 class DiaperChangeResponse(BaseModel):
@@ -70,6 +121,7 @@ class DiaperChangeResponse(BaseModel):
     timestamp: datetime
     type: DiaperType
     notes: str | None
+    child_id: int | None = None
     created_at: datetime
 
 
@@ -85,6 +137,7 @@ class FeedingCreate(BaseModel):
     notes: str | None = None
     session_id: str | None = None
     bottle_type: BottleType | None = None
+    child_id: int | None = None
 
     @model_validator(mode="after")
     def validate_bottle_amount(self) -> Self:
@@ -105,6 +158,7 @@ class FeedingUpdate(BaseModel):
     amount_unit: BottleUnit | None = None
     notes: str | None = None
     bottle_type: BottleType | None = None
+    child_id: int | None = None
 
     @model_validator(mode="after")
     def validate_bottle_amount(self) -> Self:
@@ -129,6 +183,7 @@ class FeedingResponse(BaseModel):
     notes: str | None
     session_id: str | None
     bottle_type: BottleType | None
+    child_id: int | None = None
     created_at: datetime
 
 
@@ -149,6 +204,7 @@ class MedicationCreate(BaseModel):
     dosage_quantity: float
     dosage_unit: DosageUnit
     notes: str | None = None
+    child_id: int | None = None
 
     @field_validator("dosage_quantity")
     @classmethod
@@ -162,6 +218,7 @@ class MedicationUpdate(BaseModel):
     dosage_quantity: float | None = None
     dosage_unit: DosageUnit | None = None
     notes: str | None = None
+    child_id: int | None = None
 
     @field_validator("dosage_quantity")
     @classmethod
@@ -180,6 +237,7 @@ class MedicationResponse(BaseModel):
     dosage_quantity: float
     dosage_unit: str
     notes: str | None
+    child_id: int | None = None
     created_at: datetime
 
 
@@ -191,6 +249,7 @@ class TemperatureCreate(BaseModel):
     temperature_celsius: float
     location: TemperatureLocation | None = None
     notes: str | None = None
+    child_id: int | None = None
 
 
 class TemperatureUpdate(BaseModel):
@@ -198,6 +257,7 @@ class TemperatureUpdate(BaseModel):
     temperature_celsius: float | None = None
     location: TemperatureLocation | None = None
     notes: str | None = None
+    child_id: int | None = None
 
 
 class TemperatureResponse(BaseModel):
@@ -208,6 +268,7 @@ class TemperatureResponse(BaseModel):
     temperature_celsius: float
     location: TemperatureLocation | None
     notes: str | None
+    child_id: int | None = None
     created_at: datetime
 
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -714,3 +714,98 @@ body {
     color: var(--text-secondary);
     margin-bottom: 12px;
 }
+
+.settings-hint {
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+    margin: -6px 0 12px;
+}
+
+/* ===== Child Profiles ===== */
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+.child-switcher-section {
+    margin-bottom: 16px;
+}
+
+.child-switcher {
+    width: 100%;
+    padding: 12px;
+    font-size: 1rem;
+    font-weight: 600;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--card-bg);
+    color: var(--text);
+}
+
+.child-log-title {
+    font-size: 1.1rem;
+    font-weight: 600;
+    text-align: center;
+    margin-bottom: 12px;
+    color: var(--text);
+}
+
+.unassigned-bar {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 12px;
+    margin-bottom: 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--card-bg);
+}
+
+.unassigned-bar-count {
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+}
+
+.unassigned-bar-actions {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.child-list {
+    margin-bottom: 12px;
+}
+
+.child-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.child-row-name,
+.child-rename-input {
+    flex: 1;
+    min-width: 0;
+}
+
+.child-add-row {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+}
+
+.child-add-row input {
+    flex: 1;
+    min-width: 0;
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -120,6 +120,404 @@ function updateBreastLabels() {
     if (rightLabel) rightLabel.textContent = `🤱 ${names.right} breast (minutes)`;
 }
 
+/* ===== Child Profiles ===== */
+// Profiles themselves live server-side with the logs they label; only the
+// *selection* is per-device, so two phones can view two children at once.
+const SELECTED_CHILD_KEY = 'puffin-selected-child';
+const UNASSIGNED_VIEW = 'unassigned';
+
+let childProfiles = [];
+let unassignedCount = 0;
+// null means "every log regardless of child" — what an install with no
+// profiles always shows, and exactly how Puffin behaved before profiles.
+let selectedChild = null;
+
+function hasProfiles() {
+    return childProfiles.length > 0;
+}
+
+function readStoredChild() {
+    const raw = localStorage.getItem(SELECTED_CHILD_KEY);
+    if (!raw) return null;
+    if (raw === UNASSIGNED_VIEW) return UNASSIGNED_VIEW;
+    const id = parseInt(raw, 10);
+    return Number.isNaN(id) ? null : id;
+}
+
+function storeSelectedChild(value) {
+    if (value === null) localStorage.removeItem(SELECTED_CHILD_KEY);
+    else localStorage.setItem(SELECTED_CHILD_KEY, String(value));
+}
+
+/** The current scope as a query fragment appended to dashboard/activity calls. */
+function childQuery() {
+    if (selectedChild === UNASSIGNED_VIEW) return '&unassigned=true';
+    if (typeof selectedChild === 'number') return `&child_id=${selectedChild}`;
+    return '';
+}
+
+/**
+ * The child new logs are created against.
+ *
+ * Returns null in the unassigned view so a log created while looking at
+ * unassigned logs stays unassigned, matching what is on screen.
+ */
+function currentChildId() {
+    return typeof selectedChild === 'number' ? selectedChild : null;
+}
+
+function resolveSelectedChild() {
+    if (!hasProfiles()) return null;
+    const stored = readStoredChild();
+    // The unassigned view only survives while it still has something in it.
+    if (stored === UNASSIGNED_VIEW && unassignedCount > 0) return UNASSIGNED_VIEW;
+    if (typeof stored === 'number' && childProfiles.some(c => c.id === stored)) return stored;
+    return childProfiles[0].id; // default: the first profile created
+}
+
+async function loadChildren() {
+    try {
+        const [profiles, unassigned] = await Promise.all([
+            api.get('/api/children'),
+            api.get('/api/children/unassigned'),
+        ]);
+        childProfiles = profiles;
+        unassignedCount = unassigned.count;
+    } catch (err) {
+        console.error('Failed to load children:', err);
+        childProfiles = [];
+        unassignedCount = 0;
+    }
+    selectedChild = resolveSelectedChild();
+    storeSelectedChild(selectedChild);
+    renderChildSwitcher();
+    renderChildHeader();
+}
+
+function childOptionsHtml() {
+    return childProfiles
+        .map(c => `<option value="${c.id}">${escapeHtml(c.name)}</option>`)
+        .join('');
+}
+
+function renderChildSwitcher() {
+    const section = document.getElementById('child-switcher-section');
+    const select = document.getElementById('child-switcher');
+    section.classList.toggle('hidden', !hasProfiles());
+    if (!hasProfiles()) {
+        select.innerHTML = '';
+        return;
+    }
+    let html = childOptionsHtml();
+    // Offered only while logs actually sit outside every profile.
+    if (unassignedCount > 0) {
+        html += `<option value="${UNASSIGNED_VIEW}">Unassigned logs</option>`;
+    }
+    select.innerHTML = html;
+    select.value = String(selectedChild);
+}
+
+function selectedChildName() {
+    const match = childProfiles.find(c => c.id === selectedChild);
+    return match ? match.name : null;
+}
+
+function renderChildHeader() {
+    const title = document.getElementById('child-log-title');
+    const bar = document.getElementById('unassigned-bar');
+    const name = selectedChildName();
+
+    if (selectedChild === UNASSIGNED_VIEW) {
+        title.textContent = 'Unassigned Logs';
+    } else if (name) {
+        title.textContent = `${name}'s Care Logs`;
+    } else {
+        title.textContent = '';
+    }
+    title.classList.toggle('hidden', !title.textContent);
+
+    // The bulk re-assign is the permanent escape hatch that makes declining the
+    // one-time migration offer recoverable.
+    const showBar = selectedChild === UNASSIGNED_VIEW && hasProfiles();
+    bar.classList.toggle('hidden', !showBar);
+    if (showBar) {
+        const plural = unassignedCount === 1 ? '' : 's';
+        document.getElementById('unassigned-bar-count').textContent =
+            `${unassignedCount} log${plural} not linked to any child`;
+        document.getElementById('unassigned-assign-target').innerHTML = childOptionsHtml();
+    }
+}
+
+async function refreshChildUI() {
+    await loadChildren();
+    renderChildList();
+    renderExportChildOptions();
+    loadDashboard();
+}
+
+/**
+ * Reload after a change that may have moved a log in or out of unassigned.
+ *
+ * Editing a log's child, or deleting one, changes the unassigned count — and
+ * that count decides whether `Unassigned logs` is in the switcher at all.
+ * Refreshing only the dashboard would leave a freshly-unassigned log with no
+ * way to reach it until the page was reloaded.
+ */
+function reloadAfterLogChange() {
+    if (hasProfiles()) return refreshChildUI();
+    return loadDashboard();
+}
+
+/* --- Shared two-step confirmation --- */
+
+function showChildConfirm({ title, body, note, primary, secondary, cancel,
+                            onPrimary, onSecondary, onCancel }) {
+    document.getElementById('child-confirm-title').textContent = title;
+    document.getElementById('child-confirm-body').textContent = body;
+
+    const noteEl = document.getElementById('child-confirm-note');
+    noteEl.textContent = note || '';
+    noteEl.classList.toggle('hidden', !note);
+
+    const wire = (id, label, handler) => {
+        const btn = document.getElementById(id);
+        btn.classList.toggle('hidden', !label);
+        if (label) btn.textContent = label;
+        // Replacing the node drops listeners from a previous step, so the
+        // buttons never accumulate stale handlers across the flow.
+        const fresh = btn.cloneNode(true);
+        btn.parentNode.replaceChild(fresh, btn);
+        if (label && handler) fresh.addEventListener('click', handler);
+    };
+    wire('child-confirm-primary', primary, onPrimary);
+    wire('child-confirm-secondary', secondary, onSecondary);
+    wire('child-confirm-cancel', cancel, onCancel);
+
+    openModal('child-confirm-modal');
+}
+
+/* --- Creating a profile, and the one-time migration offer --- */
+
+async function addChild() {
+    const input = document.getElementById('child-new-name');
+    const name = input.value.trim();
+    if (!name) {
+        showToast('Please enter a first name');
+        input.focus();
+        return;
+    }
+
+    const isFirstProfile = !hasProfiles();
+    let created;
+    try {
+        created = await api.post('/api/children', { name });
+    } catch (err) {
+        showToast('Error: ' + err.message);
+        return;
+    }
+    input.value = '';
+
+    // The bulk offer is made once: at first profile creation, on an install
+    // that already has logs.  Re-read the count so it reflects this moment.
+    if (isFirstProfile) {
+        const { count } = await api.get('/api/children/unassigned');
+        if (count > 0) {
+            offerMigration(created, count);
+            return;
+        }
+    }
+    await refreshChildUI();
+    showToast(`${created.name} added`);
+}
+
+function offerMigration(child, count) {
+    const plural = count === 1 ? '' : 's';
+    showChildConfirm({
+        title: 'Move existing logs?',
+        body: `You have ${count} care log${plural} that aren't linked to any child. `
+            + `Move them all to ${child.name}?`,
+        note: 'This bulk move is only offered once, when you create your first child. '
+            + 'You can always re-assign unassigned logs later from "Unassigned logs" '
+            + 'in the child menu.',
+        primary: 'Yes, move them',
+        secondary: 'No, leave them unassigned',
+        cancel: 'Cancel',
+        onPrimary: () => confirmMigration(child, count),
+        onSecondary: async () => {
+            closeModal('child-confirm-modal');
+            await refreshChildUI();
+            showToast(`${child.name} added`);
+        },
+        onCancel: () => cancelChildCreation(child),
+    });
+}
+
+function confirmMigration(child, count) {
+    const plural = count === 1 ? '' : 's';
+    showChildConfirm({
+        title: 'Confirm move',
+        body: `This will assign all ${count} existing log${plural} to ${child.name}. `
+            + `This can't be undone in bulk.`,
+        primary: `Confirm — move all logs to ${child.name}`,
+        secondary: 'Go back',
+        cancel: 'Cancel',
+        onPrimary: () => runBulkAssign(child),
+        onSecondary: () => offerMigration(child, count),
+        onCancel: () => cancelChildCreation(child),
+    });
+}
+
+/**
+ * Cancel backs all the way out of profile creation.
+ *
+ * Deleting the just-created profile is what makes "go back and create a
+ * different child first" work — the profile never half-exists.  It has no logs
+ * of its own yet, so nothing is stranded.
+ */
+async function cancelChildCreation(child) {
+    try {
+        await api.del(`/api/children/${child.id}`);
+    } catch (err) {
+        console.error('Failed to undo profile creation:', err);
+    }
+    closeModal('child-confirm-modal');
+    await refreshChildUI();
+    showToast('Profile creation cancelled');
+}
+
+async function runBulkAssign(child) {
+    try {
+        const result = await api.post(`/api/children/${child.id}/assign-unassigned`);
+        closeModal('child-confirm-modal');
+        await refreshChildUI();
+        const plural = result.assigned === 1 ? '' : 's';
+        showToast(`Moved ${result.assigned} log${plural} to ${child.name}`);
+    } catch (err) {
+        showToast('Error: ' + err.message);
+    }
+}
+
+/* --- Settings: the Children section --- */
+
+function renderChildList() {
+    const container = document.getElementById('child-list');
+    if (!hasProfiles()) {
+        container.innerHTML = '<p class="empty-state">No children yet.</p>';
+        return;
+    }
+    container.innerHTML = childProfiles.map(c => `
+        <div class="child-row" data-child-row="${c.id}">
+            <span class="child-row-name">${escapeHtml(c.name)}</span>
+            <button type="button" class="btn btn-sm btn-secondary" data-child-rename="${c.id}">Rename</button>
+            <button type="button" class="btn btn-sm btn-danger" data-child-delete="${c.id}">Delete</button>
+        </div>`).join('');
+}
+
+function startChildRename(childId) {
+    const child = childProfiles.find(c => c.id === childId);
+    const row = document.querySelector(`[data-child-row="${childId}"]`);
+    if (!child || !row) return;
+    row.innerHTML = `
+        <input type="text" class="child-rename-input" maxlength="30" value="${escapeAttr(child.name)}">
+        <button type="button" class="btn btn-sm btn-primary" data-child-rename-save="${childId}">Save</button>
+        <button type="button" class="btn btn-sm btn-secondary" data-child-rename-cancel="1">Cancel</button>`;
+    row.querySelector('.child-rename-input').focus();
+}
+
+async function saveChildRename(childId) {
+    const row = document.querySelector(`[data-child-row="${childId}"]`);
+    const name = row.querySelector('.child-rename-input').value.trim();
+    if (!name) {
+        showToast('Please enter a first name');
+        return;
+    }
+    try {
+        await api.put(`/api/children/${childId}`, { name });
+        await refreshChildUI();
+        showToast('Child renamed');
+    } catch (err) {
+        showToast('Error: ' + err.message);
+    }
+}
+
+function confirmChildDelete(childId) {
+    const child = childProfiles.find(c => c.id === childId);
+    if (!child) return;
+    showChildConfirm({
+        title: `Delete ${child.name}?`,
+        body: `${child.name}'s logs will be kept and moved to "Unassigned logs", `
+            + `where you can re-assign them. No log data is deleted.`,
+        primary: `Delete ${child.name}`,
+        cancel: 'Cancel',
+        onPrimary: async () => {
+            try {
+                await api.del(`/api/children/${childId}`);
+                closeModal('child-confirm-modal');
+                await refreshChildUI();
+                showToast(`${child.name} deleted — their logs are now unassigned`);
+            } catch (err) {
+                showToast('Error: ' + err.message);
+            }
+        },
+        onCancel: () => closeModal('child-confirm-modal'),
+    });
+}
+
+function initChildProfiles() {
+    document.getElementById('child-switcher').addEventListener('change', (e) => {
+        const raw = e.target.value;
+        selectedChild = raw === UNASSIGNED_VIEW ? UNASSIGNED_VIEW : parseInt(raw, 10);
+        storeSelectedChild(selectedChild);
+        renderChildHeader();
+        loadDashboard();
+    });
+
+    document.getElementById('child-add-btn').addEventListener('click', addChild);
+    document.getElementById('child-new-name').addEventListener('keydown', (e) => {
+        // The Children section lives inside the settings form; Enter here must
+        // add a child, not submit (and close) the whole settings modal.
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            addChild();
+        }
+    });
+
+    document.getElementById('child-list').addEventListener('click', (e) => {
+        const btn = e.target.closest('button');
+        if (!btn) return;
+        if (btn.dataset.childRename) startChildRename(parseInt(btn.dataset.childRename, 10));
+        else if (btn.dataset.childRenameSave) saveChildRename(parseInt(btn.dataset.childRenameSave, 10));
+        else if (btn.dataset.childRenameCancel) renderChildList();
+        else if (btn.dataset.childDelete) confirmChildDelete(parseInt(btn.dataset.childDelete, 10));
+    });
+
+    document.getElementById('unassigned-assign-btn').addEventListener('click', () => {
+        const targetId = parseInt(document.getElementById('unassigned-assign-target').value, 10);
+        const child = childProfiles.find(c => c.id === targetId);
+        if (!child) return;
+        const count = unassignedCount;
+        const plural = count === 1 ? '' : 's';
+        showChildConfirm({
+            title: `Assign all to ${child.name}?`,
+            body: `This will move all ${count} unassigned log${plural} to ${child.name}.`,
+            primary: 'Continue',
+            cancel: 'Cancel',
+            onPrimary: () => showChildConfirm({
+                title: 'Confirm assignment',
+                body: `This will assign ${count} log${plural} to ${child.name}. `
+                    + `This can't be undone in bulk.`,
+                primary: `Confirm — assign to ${child.name}`,
+                secondary: 'Go back',
+                cancel: 'Cancel',
+                onPrimary: () => runBulkAssign(child),
+                onSecondary: () => document.getElementById('unassigned-assign-btn').click(),
+                onCancel: () => closeModal('child-confirm-modal'),
+            }),
+            onCancel: () => closeModal('child-confirm-modal'),
+        });
+    });
+}
+
 /* ===== Dark Mode ===== */
 function initTheme() {
     const saved = localStorage.getItem('puffin-theme');
@@ -244,6 +642,11 @@ function getTimerState() {
 function startTimer(side) {
     const state = {
         active: true,
+        // The timer belongs to whoever was selected when it started, and keeps
+        // that child even if the user switches profiles mid-feed.  Only one
+        // timer runs at a time; simultaneous per-child timers (tandem feeding)
+        // are a separate feature.
+        childId: currentChildId(),
         segments: [{ side, startTime: new Date().toISOString(), endTime: null }],
     };
     localStorage.setItem(TIMER_KEY, JSON.stringify(state));
@@ -444,6 +847,8 @@ async function endTimer() {
                 timestamp: starts[side],
                 feeding_type: side,
                 duration_minutes: durationMinutes,
+                // A timer started before profiles existed has no childId.
+                child_id: state.childId ?? null,
             };
             if (sessionId) body.session_id = sessionId;
             promises.push(api.post('/api/feedings', body));
@@ -467,7 +872,7 @@ async function endTimer() {
             });
             showToast(`Feeding logged: ${parts.join(' + ')}`);
         }
-        loadDashboard();
+        reloadAfterLogChange();
     } catch (e) {
         confirmBtn.disabled = false;
         showToast('Error saving feeding: ' + e.message);
@@ -843,10 +1248,10 @@ function initForms() {
         const submitBtn = e.target.querySelector('button[type="submit"]');
         submitBtn.disabled = true;
         try {
-            await api.post('/api/diapers', { type, notes, timestamp });
+            await api.post('/api/diapers', { type, notes, timestamp, child_id: currentChildId() });
             closeModal('diaper-modal');
             showToast('Diaper change logged!');
-            loadDashboard();
+            reloadAfterLogChange();
         } catch (err) {
             submitBtn.disabled = false;
             showToast('Error: ' + err.message);
@@ -882,10 +1287,11 @@ function initForms() {
                         bottle_type: bottleType,
                         notes,
                         timestamp,
+                        child_id: currentChildId(),
                     });
                     closeModal('feeding-modal');
                     showToast('Feeding logged!');
-                    loadDashboard();
+                    reloadAfterLogChange();
                 } catch (err) {
                     saveBtn.disabled = false;
                     showToast('Error: ' + err.message);
@@ -924,6 +1330,7 @@ function initForms() {
                     duration_minutes: parseInt(leftDur),
                     notes: notesAttached ? undefined : notes,
                     timestamp,
+                    child_id: currentChildId(),
                 };
                 if (manualSessionId) body.session_id = manualSessionId;
                 promises.push(api.post('/api/feedings', body));
@@ -935,6 +1342,7 @@ function initForms() {
                     duration_minutes: parseInt(rightDur),
                     notes: notesAttached ? undefined : notes,
                     timestamp,
+                    child_id: currentChildId(),
                 };
                 if (manualSessionId) body.session_id = manualSessionId;
                 promises.push(api.post('/api/feedings', body));
@@ -949,12 +1357,13 @@ function initForms() {
                     bottle_type: bottleType,
                     notes: notesAttached ? undefined : notes,
                     timestamp,
+                    child_id: currentChildId(),
                 }));
             }
             await Promise.all(promises);
             closeModal('feeding-modal');
             showToast('Feeding logged!');
-            loadDashboard();
+            reloadAfterLogChange();
         } catch (err) {
             saveBtn.disabled = false;
             showToast('Error: ' + err.message);
@@ -987,10 +1396,10 @@ function initForms() {
         const submitBtn = e.target.querySelector('button[type="submit"]');
         submitBtn.disabled = true;
         try {
-            await api.post('/api/medications', { medication_name: name, dosage_quantity, dosage_unit, notes, timestamp });
+            await api.post('/api/medications', { medication_name: name, dosage_quantity, dosage_unit, notes, timestamp, child_id: currentChildId() });
             closeModal('health-modal');
             showToast('Medication logged!');
-            loadDashboard();
+            reloadAfterLogChange();
         } catch (err) {
             submitBtn.disabled = false;
             showToast('Error: ' + err.message);
@@ -1020,10 +1429,11 @@ function initForms() {
                 location,
                 notes,
                 timestamp,
+                child_id: currentChildId(),
             });
             closeModal('health-modal');
             showToast('Temperature logged!');
-            loadDashboard();
+            reloadAfterLogChange();
         } catch (err) {
             submitBtn.disabled = false;
             showToast('Error: ' + err.message);
@@ -1080,12 +1490,38 @@ async function openEditModal(type, id, secondaryId = null) {
 }
 
 function buildEditFields(type, data, secondaryData = null) {
+    let html;
     switch (type) {
-        case 'diaper': return buildDiaperEditFields(data);
-        case 'feeding': return buildFeedingEditFields(data, secondaryData);
-        case 'medication': return buildMedicationEditFields(data);
-        case 'temperature': return buildTemperatureEditFields(data);
+        case 'diaper': html = buildDiaperEditFields(data); break;
+        case 'feeding': html = buildFeedingEditFields(data, secondaryData); break;
+        case 'medication': html = buildMedicationEditFields(data); break;
+        case 'temperature': html = buildTemperatureEditFields(data); break;
     }
+    return html + buildChildEditField(data);
+}
+
+/**
+ * The child selector — the only place a single log's association can change.
+ *
+ * Hidden entirely when no profiles exist, so nothing about editing a log
+ * changes for installs that never opted in.  `Unassigned` is selectable: a log
+ * mis-assigned during a bulk move can be parked rather than forced onto the
+ * wrong child.
+ */
+function buildChildEditField(data) {
+    if (!hasProfiles()) return '';
+    const options = childProfiles.map(c =>
+        `<option value="${c.id}" ${data.child_id === c.id ? 'selected' : ''}>${escapeHtml(c.name)}</option>`
+    ).join('');
+    const unassignedSelected = data.child_id == null ? 'selected' : '';
+    return `
+        <div class="form-group">
+            <label for="edit-child">Child</label>
+            <select id="edit-child">
+                ${options}
+                <option value="" ${unassignedSelected}>Unassigned</option>
+            </select>
+        </div>`;
 }
 
 function buildDiaperEditFields(data) {
@@ -1259,6 +1695,11 @@ function buildEditBody(type) {
     }
     body.notes = notes;
 
+    // Absent when no profiles exist; an empty value means Unassigned, which
+    // must be sent as an explicit null rather than omitted.
+    const childEl = document.getElementById('edit-child');
+    if (childEl) body.child_id = childEl.value ? parseInt(childEl.value, 10) : null;
+
     switch (type) {
         case 'diaper':
             body.type = document.getElementById('edit-diaper-type').value;
@@ -1363,7 +1804,7 @@ function initEditForm() {
             }
             closeModal('edit-modal');
             showToast('Updated!');
-            loadDashboard();
+            reloadAfterLogChange();
         } catch (err) {
             showToast('Error: ' + err.message);
         }
@@ -1395,7 +1836,7 @@ function initEditForm() {
             }
             closeModal('edit-modal');
             showToast('Deleted!');
-            loadDashboard();
+            reloadAfterLogChange();
         } catch (err) {
             showToast('Error: ' + err.message);
         }
@@ -1481,7 +1922,7 @@ async function loadDayActivities() {
     const timeline = document.getElementById('timeline');
     try {
         const dateStr = toDateString(currentDate);
-        const activities = await api.get(`/api/activities?date=${dateStr}`);
+        const activities = await api.get(`/api/activities?date=${dateStr}${childQuery()}`);
         if (activities.length === 0) {
             timeline.innerHTML = '<p class="empty-state">No entries for this day.</p>';
             return;
@@ -1526,7 +1967,7 @@ function timeAgo(isoStr) {
 async function loadDashboard() {
     try {
         const dateStr = toDateString(currentDate);
-        const data = await api.get(`/api/dashboard?date=${dateStr}`);
+        const data = await api.get(`/api/dashboard?date=${dateStr}${childQuery()}`);
 
         // Summary card titles reflect the displayed day
         const isToday = isSameDay(currentDate, new Date());
@@ -1583,6 +2024,8 @@ function initSettings() {
         document.getElementById('settings-bottle-type').value = getDefaultBottleType();
         document.getElementById('settings-bottle-unit').value = getDefaultBottleUnit();
         updateBottleUnitLabels();
+        renderChildList();
+        document.getElementById('child-new-name').value = '';
         openModal('settings-modal');
     });
 
@@ -1606,8 +2049,26 @@ function initSettings() {
 }
 
 /* ===== Export Modal ===== */
+const EXPORT_ALL_CHILDREN = 'all';
+
+/** Export defaults to the child on screen, with an explicit all-children option. */
+function renderExportChildOptions() {
+    const group = document.getElementById('export-child-group');
+    const select = document.getElementById('export-child');
+    group.classList.toggle('hidden', !hasProfiles());
+    if (!hasProfiles()) {
+        select.innerHTML = '';
+        return;
+    }
+    select.innerHTML = childOptionsHtml()
+        + (unassignedCount > 0 ? `<option value="${UNASSIGNED_VIEW}">Unassigned logs</option>` : '')
+        + `<option value="${EXPORT_ALL_CHILDREN}">All children</option>`;
+    select.value = selectedChild === null ? EXPORT_ALL_CHILDREN : String(selectedChild);
+}
+
 function initExport() {
     document.getElementById('export-btn').addEventListener('click', () => {
+        renderExportChildOptions();
         openModal('export-modal');
     });
 
@@ -1620,6 +2081,13 @@ function initExport() {
         let url = `/api/export?format=${encodeURIComponent(fmt)}`;
         if (start) url += `&start_date=${encodeURIComponent(start + 'T00:00:00')}`;
         if (end) url += `&end_date=${encodeURIComponent(end + 'T23:59:59')}`;
+
+        const childEl = document.getElementById('export-child');
+        if (hasProfiles() && childEl.value !== EXPORT_ALL_CHILDREN) {
+            url += childEl.value === UNASSIGNED_VIEW
+                ? '&unassigned=true'
+                : `&child_id=${encodeURIComponent(childEl.value)}`;
+        }
 
         window.location.href = url;
         closeModal('export-modal');
@@ -1639,10 +2107,16 @@ document.addEventListener('DOMContentLoaded', () => {
     initCalendar();
     initSettings();
     initExport();
+    initChildProfiles();
     updateBreastLabels();
     updateBottleTypeLabels();
     updateBottleUnitLabels();
-    loadDashboard();
+    // Resolves the selected child before the first dashboard fetch, so the
+    // counts are never briefly wrong for a multi-child install.
+    loadChildren().then(() => {
+        renderChildList();
+        loadDashboard();
+    });
 
     // Theme toggle
     document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
@@ -1652,8 +2126,10 @@ document.addEventListener('DOMContentLoaded', () => {
         btn.addEventListener('click', () => openModal(btn.dataset.modal));
     });
 
-    // Close modal via backdrop or cancel button
-    document.querySelectorAll('.modal-backdrop').forEach(el => {
+    // Close modal via backdrop or cancel button.  Static backdrops opt out:
+    // dismissing a two-step confirmation by clicking away would strand a
+    // half-created profile.
+    document.querySelectorAll('.modal-backdrop:not(.modal-backdrop-static)').forEach(el => {
         el.addEventListener('click', closeAllModals);
     });
     document.querySelectorAll('.modal-close').forEach(el => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -17,6 +17,12 @@
     </header>
 
     <main class="container">
+        <!-- Child Switcher (hidden until at least one profile exists) -->
+        <section id="child-switcher-section" class="child-switcher-section hidden">
+            <label class="sr-only" for="child-switcher">Switch child</label>
+            <select id="child-switcher" class="child-switcher"></select>
+        </section>
+
         <!-- Active Feeding Timer -->
         <section id="timer-section" class="timer-section hidden">
             <div class="timer-display">
@@ -64,6 +70,15 @@
 
         <!-- Calendar Day View -->
         <section class="calendar-section">
+            <h2 id="child-log-title" class="child-log-title hidden"></h2>
+            <div id="unassigned-bar" class="unassigned-bar hidden">
+                <span id="unassigned-bar-count" class="unassigned-bar-count"></span>
+                <div class="unassigned-bar-actions">
+                    <button type="button" id="unassigned-assign-btn" class="btn btn-sm btn-primary">Assign all to…</button>
+                    <label class="sr-only" for="unassigned-assign-target">Assign all to</label>
+                    <select id="unassigned-assign-target"></select>
+                </div>
+            </div>
             <div class="calendar-nav">
                 <button id="cal-prev" class="btn btn-icon calendar-arrow" aria-label="Previous day">&lsaquo;</button>
                 <button id="cal-date-btn" class="calendar-date" aria-label="Pick a date">
@@ -315,6 +330,14 @@
         <div class="modal-content">
             <h2>Settings</h2>
             <form id="settings-form">
+                <h3 class="settings-section-title">Children</h3>
+                <p class="settings-hint">Optional. Add a child to track each one's logs separately.</p>
+                <div id="child-list" class="child-list"></div>
+                <div class="form-group child-add-row">
+                    <label class="sr-only" for="child-new-name">First name</label>
+                    <input type="text" id="child-new-name" maxlength="30" placeholder="First name">
+                    <button type="button" id="child-add-btn" class="btn btn-sm btn-secondary">+ Add a child</button>
+                </div>
                 <h3 class="settings-section-title">Breast Names</h3>
                 <div class="form-group">
                     <label for="settings-left-name">Left breast name</label>
@@ -370,11 +393,35 @@
                     <label for="export-end-date">End Date (optional)</label>
                     <input type="date" id="export-end-date">
                 </div>
+                <div class="form-group hidden" id="export-child-group">
+                    <label for="export-child">Child</label>
+                    <select id="export-child"></select>
+                </div>
                 <div class="form-actions">
                     <button type="submit" class="btn btn-primary btn-lg">Download</button>
                     <button type="button" class="btn btn-secondary modal-close">Cancel</button>
                 </div>
             </form>
+        </div>
+    </div>
+
+    <!--
+      Two-step confirmation shared by the first-profile migration offer and the
+      bulk re-assign from the unassigned view.  Its backdrop is marked static so
+      a stray click cannot dismiss a half-finished migration — every exit runs
+      through the buttons, which clean up after themselves.
+    -->
+    <div id="child-confirm-modal" class="modal hidden">
+        <div class="modal-backdrop modal-backdrop-static"></div>
+        <div class="modal-content">
+            <h2 id="child-confirm-title"></h2>
+            <p id="child-confirm-body"></p>
+            <p id="child-confirm-note" class="settings-hint hidden"></p>
+            <div class="form-actions">
+                <button type="button" id="child-confirm-primary" class="btn btn-primary btn-lg"></button>
+                <button type="button" id="child-confirm-secondary" class="btn btn-secondary"></button>
+                <button type="button" id="child-confirm-cancel" class="btn btn-secondary"></button>
+            </div>
         </div>
     </div>
 

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -1,0 +1,318 @@
+"""Tests for optional child profiles (issue #44).
+
+Profiles are opt-in: an install with no profiles must behave exactly as Puffin
+did before they existed, which is what ``test_zero_profiles_*`` guards.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def child(client):
+    """A single profile named Maya."""
+    return client.post("/api/children", json={"name": "Maya"}).json()
+
+
+@pytest.fixture
+def two_children(client):
+    maya = client.post("/api/children", json={"name": "Maya"}).json()
+    theo = client.post("/api/children", json={"name": "Theo"}).json()
+    return maya, theo
+
+
+# --- Profile CRUD ---
+
+
+def test_create_child(client):
+    resp = client.post("/api/children", json={"name": "Maya"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["name"] == "Maya"
+    assert data["id"] is not None
+
+
+def test_create_child_trims_name(client):
+    resp = client.post("/api/children", json={"name": "  Maya  "})
+    assert resp.status_code == 201
+    assert resp.json()["name"] == "Maya"
+
+
+@pytest.mark.parametrize("name", ["", "   "])
+def test_create_child_rejects_blank_name(client, name):
+    assert client.post("/api/children", json={"name": name}).status_code == 422
+
+
+def test_list_children_is_creation_ordered(client, two_children):
+    """Creation order is the switcher's order and picks the default child."""
+    names = [c["name"] for c in client.get("/api/children").json()]
+    assert names == ["Maya", "Theo"]
+
+
+def test_rename_child(client, child):
+    resp = client.put(f"/api/children/{child['id']}", json={"name": "Maya Rose"})
+    assert resp.status_code == 200
+    assert resp.json()["name"] == "Maya Rose"
+
+
+def test_rename_child_not_found(client):
+    assert client.put("/api/children/999", json={"name": "Ghost"}).status_code == 404
+
+
+def test_delete_child_not_found(client):
+    assert client.delete("/api/children/999").status_code == 404
+
+
+# --- Deleting a profile keeps its logs ---
+
+
+def test_delete_child_unassigns_logs_rather_than_deleting_them(client, child):
+    cid = child["id"]
+    diaper = client.post("/api/diapers", json={"type": "pee", "child_id": cid}).json()
+    feeding = client.post(
+        "/api/feedings", json={"feeding_type": "breast_left", "child_id": cid}
+    ).json()
+
+    assert client.delete(f"/api/children/{cid}").status_code == 204
+
+    # Logs survive, stripped of the association.
+    assert client.get(f"/api/diapers/{diaper['id']}").json()["child_id"] is None
+    assert client.get(f"/api/feedings/{feeding['id']}").json()["child_id"] is None
+    assert client.get("/api/children/unassigned").json()["count"] == 2
+
+
+def test_delete_child_leaves_other_childs_logs_alone(client, two_children):
+    maya, theo = two_children
+    kept = client.post("/api/diapers", json={"type": "pee", "child_id": theo["id"]}).json()
+    client.post("/api/diapers", json={"type": "poop", "child_id": maya["id"]})
+
+    client.delete(f"/api/children/{maya['id']}")
+
+    assert client.get(f"/api/diapers/{kept['id']}").json()["child_id"] == theo["id"]
+    assert client.get("/api/children/unassigned").json()["count"] == 1
+
+
+# --- Unassigned count and bulk assignment ---
+
+
+def test_unassigned_count_spans_every_log_type(client):
+    client.post("/api/diapers", json={"type": "pee"})
+    client.post("/api/feedings", json={"feeding_type": "breast_left"})
+    client.post(
+        "/api/medications",
+        json={"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"},
+    )
+    client.post("/api/temperatures", json={"temperature_celsius": 37.0})
+
+    assert client.get("/api/children/unassigned").json()["count"] == 4
+
+
+def test_bulk_assign_moves_every_unassigned_log(client, child):
+    """The one-time migration offer and the later bulk re-assign share this."""
+    client.post("/api/diapers", json={"type": "pee"})
+    client.post("/api/feedings", json={"feeding_type": "bottle", "amount": 3, "amount_unit": "oz"})
+    client.post("/api/temperatures", json={"temperature_celsius": 37.0})
+
+    resp = client.post(f"/api/children/{child['id']}/assign-unassigned")
+    assert resp.status_code == 200
+    assert resp.json()["assigned"] == 3
+    assert client.get("/api/children/unassigned").json()["count"] == 0
+
+
+def test_bulk_assign_leaves_already_assigned_logs_with_their_child(client, two_children):
+    maya, theo = two_children
+    theos = client.post("/api/diapers", json={"type": "pee", "child_id": theo["id"]}).json()
+    client.post("/api/diapers", json={"type": "poop"})  # unassigned
+
+    assert client.post(f"/api/children/{maya['id']}/assign-unassigned").json()["assigned"] == 1
+    assert client.get(f"/api/diapers/{theos['id']}").json()["child_id"] == theo["id"]
+
+
+def test_bulk_assign_unknown_child_is_404(client):
+    assert client.post("/api/children/999/assign-unassigned").status_code == 404
+
+
+# --- Assigning logs at creation and by editing ---
+
+
+def test_create_log_with_child(client, child):
+    resp = client.post("/api/diapers", json={"type": "pee", "child_id": child["id"]})
+    assert resp.status_code == 201
+    assert resp.json()["child_id"] == child["id"]
+
+
+def test_edit_log_moves_it_between_children(client, two_children):
+    maya, theo = two_children
+    log = client.post("/api/diapers", json={"type": "pee", "child_id": maya["id"]}).json()
+
+    resp = client.put(f"/api/diapers/{log['id']}", json={"child_id": theo["id"]})
+    assert resp.status_code == 200
+    assert resp.json()["child_id"] == theo["id"]
+
+
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        ("/api/diapers", {"type": "pee"}),
+        ("/api/feedings", {"feeding_type": "breast_left"}),
+        (
+            "/api/medications",
+            {"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"},
+        ),
+        ("/api/temperatures", {"temperature_celsius": 37.0}),
+    ],
+)
+def test_edit_log_can_set_child_back_to_unassigned(client, child, path, payload):
+    """An explicit null must unassign rather than read as "field omitted"."""
+    log = client.post(path, json={**payload, "child_id": child["id"]}).json()
+
+    resp = client.put(f"{path}/{log['id']}", json={"child_id": None})
+    assert resp.status_code == 200
+    assert resp.json()["child_id"] is None
+
+
+def test_edit_without_child_id_leaves_association_untouched(client, child):
+    """Omitting child_id must not silently orphan the log."""
+    log = client.post("/api/diapers", json={"type": "pee", "child_id": child["id"]}).json()
+
+    resp = client.put(f"/api/diapers/{log['id']}", json={"notes": "updated"})
+    assert resp.json()["child_id"] == child["id"]
+    assert resp.json()["notes"] == "updated"
+
+
+# --- Dashboard and activity scoping ---
+
+
+def test_dashboard_counts_only_the_selected_child(client, two_children):
+    maya, theo = two_children
+    client.post("/api/diapers", json={"type": "pee", "child_id": maya["id"]})
+    client.post("/api/diapers", json={"type": "poop", "child_id": maya["id"]})
+    client.post("/api/diapers", json={"type": "pee", "child_id": theo["id"]})
+
+    assert client.get(f"/api/dashboard?child_id={maya['id']}").json()["diaper_stats"]["today"] == 2
+    assert client.get(f"/api/dashboard?child_id={theo['id']}").json()["diaper_stats"]["today"] == 1
+
+
+def test_dashboard_last_activity_is_scoped(client, two_children):
+    """ "Last fed" must never report the other child's feeding."""
+    maya, theo = two_children
+    client.post("/api/feedings", json={"feeding_type": "breast_left", "child_id": maya["id"]})
+    theos = client.post(
+        "/api/feedings",
+        json={"feeding_type": "bottle", "amount": 3, "amount_unit": "oz", "child_id": theo["id"]},
+    ).json()
+
+    last = client.get(f"/api/dashboard?child_id={theo['id']}").json()["last_feeding"]
+    assert last["id"] == theos["id"]
+
+
+def test_dashboard_unassigned_filter(client, child):
+    client.post("/api/diapers", json={"type": "pee", "child_id": child["id"]})
+    client.post("/api/diapers", json={"type": "poop"})
+
+    resp = client.get("/api/dashboard?unassigned=true").json()
+    assert resp["diaper_stats"]["today"] == 1
+
+
+def test_activities_scoped_to_child(client, two_children):
+    maya, theo = two_children
+    client.post("/api/diapers", json={"type": "pee", "child_id": maya["id"]})
+    client.post("/api/diapers", json={"type": "poop", "child_id": theo["id"]})
+
+    date = client.get("/api/diapers").json()[0]["timestamp"][:10]
+    items = client.get(f"/api/activities?date={date}&child_id={maya['id']}").json()
+    assert len(items) == 1
+    assert items[0]["subtype"] == "pee"
+
+
+def test_list_endpoints_scoped_to_child(client, two_children):
+    maya, theo = two_children
+    client.post("/api/diapers", json={"type": "pee", "child_id": maya["id"]})
+    client.post("/api/diapers", json={"type": "poop", "child_id": theo["id"]})
+    client.post("/api/diapers", json={"type": "pee"})
+
+    assert len(client.get(f"/api/diapers?child_id={maya['id']}").json()) == 1
+    assert len(client.get("/api/diapers?unassigned=true").json()) == 1
+    assert len(client.get("/api/diapers").json()) == 3
+
+
+def test_unassigned_wins_over_child_id(client, child):
+    """The two filters can never combine into an impossible query."""
+    client.post("/api/diapers", json={"type": "pee", "child_id": child["id"]})
+    client.post("/api/diapers", json={"type": "poop"})
+
+    resp = client.get(f"/api/diapers?child_id={child['id']}&unassigned=true").json()
+    assert len(resp) == 1
+    assert resp[0]["child_id"] is None
+
+
+# --- Export scoping ---
+
+
+def test_export_csv_scoped_to_child_has_no_child_column(client, two_children):
+    maya, theo = two_children
+    client.post("/api/diapers", json={"type": "pee", "child_id": maya["id"]})
+    client.post("/api/diapers", json={"type": "poop", "child_id": theo["id"]})
+
+    body = client.get(f"/api/export?format=csv&child_id={maya['id']}").text
+    assert "child" not in body.splitlines()[1]
+    assert "pee" in body
+    assert "poop" not in body
+
+
+def test_export_csv_all_children_includes_child_column(client, two_children):
+    maya, theo = two_children
+    client.post("/api/diapers", json={"type": "pee", "child_id": maya["id"]})
+    client.post("/api/diapers", json={"type": "poop", "child_id": theo["id"]})
+    client.post("/api/temperatures", json={"temperature_celsius": 37.0})
+
+    body = client.get("/api/export?format=csv").text
+    assert body.splitlines()[1].endswith("child")
+    assert "Maya" in body
+    assert "Theo" in body
+    assert "Unassigned" in body  # the temperature belongs to no profile
+
+
+def test_export_json_all_children_includes_child_lookup(client, child):
+    client.post("/api/diapers", json={"type": "pee", "child_id": child["id"]})
+
+    data = client.get("/api/export?format=json").json()
+    assert data["children"] == {str(child["id"]): "Maya"}
+    assert data["diapers"][0]["child_id"] == child["id"]
+
+
+def test_export_json_scoped_omits_child_lookup(client, child):
+    client.post("/api/diapers", json={"type": "pee", "child_id": child["id"]})
+
+    data = client.get(f"/api/export?format=json&child_id={child['id']}").json()
+    assert "children" not in data
+
+
+def test_export_pdf_still_renders_with_children(client, two_children):
+    maya, _ = two_children
+    client.post("/api/diapers", json={"type": "pee", "child_id": maya["id"]})
+
+    resp = client.get("/api/export?format=pdf")
+    assert resp.status_code == 200
+    assert resp.content[:4] == b"%PDF"
+
+
+# --- Zero-profile installs are untouched ---
+
+
+def test_zero_profiles_dashboard_counts_every_log(client):
+    client.post("/api/diapers", json={"type": "pee"})
+    client.post("/api/diapers", json={"type": "poop"})
+
+    assert client.get("/api/dashboard").json()["diaper_stats"]["today"] == 2
+
+
+def test_zero_profiles_export_has_no_child_column(client):
+    client.post("/api/diapers", json={"type": "pee"})
+
+    body = client.get("/api/export?format=csv").text
+    assert "child" not in body.splitlines()[1]
+
+
+def test_zero_profiles_children_list_is_empty(client):
+    assert client.get("/api/children").json() == []
+    assert client.get("/api/children/unassigned").json()["count"] == 0

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -108,6 +108,45 @@ def test_migration_renames_feeding_amount_column(legacy_engine):
     assert rows[1] == ("breast_left", None, None)
 
 
+@pytest.mark.parametrize(
+    "table",
+    ["diaper_changes", "feedings", "medications", "temperature_readings"],
+)
+def test_migration_adds_child_id_to_every_log_table(legacy_engine, table):
+    """Issue #44 — profiles are opt-in, so the column must simply exist."""
+    with legacy_engine.connect() as conn:
+        cols = {c["name"] for c in inspect(conn).get_columns(table)}
+    assert "child_id" in cols
+
+
+def test_migration_leaves_existing_logs_unassigned(legacy_engine):
+    """No log is silently adopted by a profile — bulk assignment is opt-in.
+
+    ``feedings`` is the sharp case: it is rebuilt wholesale by the amount_oz
+    rename, so this also proves ``child_id`` survives that rebuild.
+    """
+    with legacy_engine.connect() as conn:
+        for table in ("feedings", "medications"):
+            rows = conn.execute(text(f"SELECT child_id FROM {table}")).fetchall()  # noqa: S608
+            assert rows, f"expected seeded rows in {table}"
+            assert all(child_id is None for (child_id,) in rows)
+
+
+def test_migration_creates_children_table(legacy_engine):
+    with legacy_engine.connect() as conn:
+        assert inspect(conn).has_table("children")
+        assert conn.execute(text("SELECT COUNT(*) FROM children")).scalar() == 0
+
+
+def test_migration_is_idempotent_for_child_id(legacy_engine):
+    """Startup runs migrations every time; a second pass must be a no-op."""
+    _run_migrations(bind=legacy_engine)
+    _run_migrations(bind=legacy_engine)
+    with legacy_engine.connect() as conn:
+        cols = [c["name"] for c in inspect(conn).get_columns("diaper_changes")]
+    assert cols.count("child_id") == 1
+
+
 def test_migration_adds_amount_unit_to_current_amount_schema(tmp_path):
     db_path = tmp_path / "amount_without_unit.db"
     raw = sqlite3.connect(db_path)


### PR DESCRIPTION
Implements #44.

## What this adds

An **optional** child profile, created from Settings with just a first name. When at least one profile exists, a switcher appears at the top of the page and the dashboard scopes itself to the selected child — summary counts, last-activity timestamps, timeline, and export all reflect that child alone.

Every log gains an optional child association, changeable by editing the log. The child's name never appears in the log's own row — the page header already says whose logs these are.

## Why

Puffin is single-child by design today. A family with twins, or a toddler and a newborn, can only run a second container or log everything into one stream — at which point `Diapers Today: 6` stops meaning anything and a PDF handed to a pediatrician mixes both children's records.

## Puffin is unchanged if you never create a profile

No switcher, no header, counts over all logs — exactly as before. This is the case `test_zero_profiles_*` guards, and it's what an existing install sees until it opts in.

## Data model

- New `children` table; nullable `child_id` on the four log tables.
- `NULL` means **unassigned**: the state of every pre-existing log, of logs whose profile was deleted, and of logs deliberately set back by editing.
- Profiles live **server-side** with the logs they label — unlike every existing setting, which is `localStorage`-only. A `child_id` written on one device has to resolve to a name on every other. Only the current *selection* stays per-device, so two parents can view two different children simultaneously.

## Migration, split in two

**Schema (automatic):** creates `children`, adds nullable `child_id`. Reads and reinterprets no log data — existing rows get `NULL`. Follows the existing hand-rolled idempotent pattern in `_run_migrations()`.

**Data (user-initiated, offered once):** at first profile creation on an install that already has logs, a two-step confirmation offers to move them all. **Cancel at either step deletes the just-created profile**, so a parent who meant to add a different child first backs all the way out rather than leaving a half-created profile.

Declining is recoverable: the unassigned view carries a bulk re-assign behind the same two-step confirmation. **Deleting a profile never deletes logs** — they return to unassigned.

## Reviewer notes

- **Migration ordering is load-bearing.** The `child_id` block must run *after* the `feedings` table rebuild (which recreates the table without `child_id`) and *before* the medications early-`return`, or it silently skips some databases. `test_migration_leaves_existing_logs_unassigned` covers the feedings case specifically.
- **`child_id` updates key off pydantic's `fields_set`, not `None`.** An explicit null is how a log moves back to unassigned, so the usual `if v is not None` guard would silently swallow it.
- **Timer scope is deliberate.** The timer belongs to the child selected when it started and keeps that child if the user switches mid-feed. Only one runs at a time — simultaneous per-child timers (twin tandem feeding) need the timer's single `localStorage` state reworked and are left to a follow-up.
- **`Unassigned logs` is conditional** — it appears in the switcher only while logs actually sit outside every profile, and disappears once they don't.
- Removes a pre-existing unused import in `routers/health.py` that sat in an import block this change already touches. Unrelated to the feature, but `lint` was already failing on it at `main`.

## Testing

128 tests pass (42 new); `lint` and `format` clean.

Also driven end-to-end in the browser against a scratch database: zero-profile install unchanged, full migration flow including cancel-and-rollback, no repeat offer on the second profile, per-child counts, new logs attaching to the selected child, explicit unassign, delete-preserves-logs, bulk re-assign, and export in all three formats.

That browser pass caught a bug the tests missed: after unassigning a log via edit, the switcher didn't refresh its unassigned count, so `Unassigned logs` never appeared and the log was unreachable until a page reload. Fixed with `reloadAfterLogChange()`, applied to every create/edit/delete path.

## Not included

While testing, logs created in the evening didn't appear in "today" counts. That turned out to be pre-existing and unrelated: `_get_local_tz()` defaults to UTC when `TZ` is unset, so evening logs in a western timezone land on the next UTC day. `TZ` is documented only in a docstring — not the README or the `docker run` example. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
