### PR TITLE
Fix seven data-correctness bugs in stats, child scoping, and the timer

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -93,14 +93,18 @@ def _period_count(db: Session, model, timestamp_col, period: str, child: ChildFi
     local_tz = _get_local_tz()
     now = datetime.now(local_tz)
     if period == "today":
-        local_midnight = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        start = local_midnight.astimezone(UTC)
+        start = now.replace(hour=0, minute=0, second=0, microsecond=0)
     elif period == "week":
         start = now - timedelta(days=7)
     elif period == "month":
         start = now - timedelta(days=30)
     else:
         start = now
+    # Timestamps are stored as UTC, and SQLite drops tzinfo when binding a
+    # datetime — so every bound must be converted before it is compared, not
+    # just the "today" one.  Without this the week/month windows are off by
+    # the local UTC offset.
+    start = start.astimezone(UTC)
     stmt = select(func.count()).select_from(model).where(timestamp_col >= start)
     stmt = _child_where(stmt, model.child_id, child)
     return db.execute(stmt).scalar() or 0

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -3,7 +3,7 @@ import re
 from datetime import UTC, datetime
 from pathlib import Path
 
-from sqlalchemy import create_engine, inspect, text
+from sqlalchemy import create_engine, event, inspect, text
 from sqlalchemy.orm import DeclarativeBase, sessionmaker
 
 _DOSAGE_UNIT_MAP = {
@@ -64,6 +64,22 @@ DB_PATH = os.environ.get(
 DATABASE_URL = f"sqlite:///{DB_PATH}"
 
 engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+
+
+@event.listens_for(engine, "connect")
+def _enable_foreign_keys(dbapi_connection, connection_record):
+    """Enforce foreign keys, which SQLite leaves off per-connection by default.
+
+    Without this the ``ondelete`` clauses on every log table are inert and a
+    bad ``child_id`` is written happily, orphaning the log where no view can
+    reach it.  Application-level validation in ``dependencies`` is the real
+    guard; this is the backstop for any write that bypasses it.
+    """
+    cursor = dbapi_connection.cursor()
+    cursor.execute("PRAGMA foreign_keys=ON")
+    cursor.close()
+
+
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 

--- a/src/puffin/dependencies.py
+++ b/src/puffin/dependencies.py
@@ -1,5 +1,7 @@
-from fastapi import Query
+from fastapi import HTTPException, Query
+from sqlalchemy.orm import Session
 
+from puffin import crud
 from puffin.crud import UNASSIGNED, ChildFilter
 
 
@@ -16,3 +18,21 @@ def child_filter(
     if unassigned:
         return UNASSIGNED
     return child_id
+
+
+def validate_child_id(db: Session, child_id: int | None) -> None:
+    """Reject a ``child_id`` that does not name an existing profile.
+
+    ``None`` is always valid — it means "unassigned".
+
+    Nothing at the database level catches this: SQLite enforces foreign keys
+    only when ``PRAGMA foreign_keys=ON``, so an orphaned log is written
+    happily.  It is then invisible everywhere — no child's scoped view
+    matches it, and the unassigned view filters on ``child_id IS NULL`` — so
+    the log cannot be reached or recovered through the UI.  A client holding
+    a profile id deleted in another tab is enough to trigger it.
+    """
+    if child_id is None:
+        return
+    if crud.get_child(db, child_id) is None:
+        raise HTTPException(status_code=422, detail=f"Child {child_id} not found")

--- a/src/puffin/routers/diapers.py
+++ b/src/puffin/routers/diapers.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from puffin import crud
 from puffin.crud import ChildFilter
 from puffin.database import get_db
-from puffin.dependencies import child_filter
+from puffin.dependencies import child_filter, validate_child_id
 from puffin.schemas import DiaperChangeCreate, DiaperChangeResponse, DiaperChangeUpdate, PeriodStats
 
 router = APIRouter(prefix="/api/diapers", tags=["diapers"])
@@ -14,6 +14,7 @@ router = APIRouter(prefix="/api/diapers", tags=["diapers"])
 
 @router.post("", response_model=DiaperChangeResponse, status_code=201)
 def create_diaper(data: DiaperChangeCreate, db: Session = Depends(get_db)):
+    validate_child_id(db, data.child_id)
     return crud.create_diaper(
         db,
         timestamp=data.timestamp,
@@ -65,6 +66,7 @@ def update_diaper(diaper_id: int, data: DiaperChangeUpdate, db: Session = Depend
     # ``child_id`` keys off fields_set, not None: an explicit null is how a log
     # is moved back to unassigned.
     if "child_id" in data.model_fields_set:
+        validate_child_id(db, data.child_id)
         updates["child_id"] = data.child_id
     obj = crud.update_diaper(db, diaper_id, **updates)
     if not obj:

--- a/src/puffin/routers/feedings.py
+++ b/src/puffin/routers/feedings.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from puffin import crud
 from puffin.crud import ChildFilter
 from puffin.database import get_db
-from puffin.dependencies import child_filter
+from puffin.dependencies import child_filter, validate_child_id
 from puffin.schemas import FeedingCreate, FeedingResponse, FeedingUpdate, PeriodStats
 
 router = APIRouter(prefix="/api/feedings", tags=["feedings"])
@@ -14,6 +14,7 @@ router = APIRouter(prefix="/api/feedings", tags=["feedings"])
 
 @router.post("", response_model=FeedingResponse, status_code=201)
 def create_feeding(data: FeedingCreate, db: Session = Depends(get_db)):
+    validate_child_id(db, data.child_id)
     return crud.create_feeding(
         db,
         timestamp=data.timestamp,
@@ -87,6 +88,7 @@ def update_feeding(feeding_id: int, data: FeedingUpdate, db: Session = Depends(g
     # ``child_id`` keys off fields_set, not None: an explicit null is how a log
     # is moved back to unassigned.
     if "child_id" in data.model_fields_set:
+        validate_child_id(db, data.child_id)
         updates["child_id"] = data.child_id
     return crud.update_feeding(db, feeding_id, **updates)
 

--- a/src/puffin/routers/health.py
+++ b/src/puffin/routers/health.py
@@ -6,7 +6,7 @@ from sqlalchemy.orm import Session
 from puffin import crud
 from puffin.crud import ChildFilter
 from puffin.database import get_db
-from puffin.dependencies import child_filter
+from puffin.dependencies import child_filter, validate_child_id
 from puffin.schemas import (
     MedicationCreate,
     MedicationResponse,
@@ -25,6 +25,7 @@ router = APIRouter(tags=["health"])
 
 @router.post("/api/medications", response_model=MedicationResponse, status_code=201)
 def create_medication(data: MedicationCreate, db: Session = Depends(get_db)):
+    validate_child_id(db, data.child_id)
     result = crud.create_medication(
         db,
         timestamp=data.timestamp,
@@ -89,6 +90,7 @@ def update_medication(medication_id: int, data: MedicationUpdate, db: Session = 
     # ``child_id`` keys off fields_set, not None: an explicit null is how a log
     # is moved back to unassigned.
     if "child_id" in data.model_fields_set:
+        validate_child_id(db, data.child_id)
         updates["child_id"] = data.child_id
     obj = crud.update_medication(db, medication_id, **updates)
     if not obj:
@@ -107,6 +109,7 @@ def delete_medication(medication_id: int, db: Session = Depends(get_db)):
 
 @router.post("/api/temperatures", response_model=TemperatureResponse, status_code=201)
 def create_temperature(data: TemperatureCreate, db: Session = Depends(get_db)):
+    validate_child_id(db, data.child_id)
     return crud.create_temperature(
         db,
         timestamp=data.timestamp,
@@ -153,6 +156,7 @@ def update_temperature(temp_id: int, data: TemperatureUpdate, db: Session = Depe
     # ``child_id`` keys off fields_set, not None: an explicit null is how a log
     # is moved back to unassigned.
     if "child_id" in data.model_fields_set:
+        validate_child_id(db, data.child_id)
         updates["child_id"] = data.child_id
     obj = crud.update_temperature(db, temp_id, **updates)
     if not obj:

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -184,9 +184,14 @@ async function loadChildren() {
         childProfiles = profiles;
         unassignedCount = unassigned.count;
     } catch (err) {
+        // Do NOT fall back to an empty profile list: that is indistinguishable
+        // from a genuine zero-profile install, and persisting it would clear
+        // the stored selection and silently route every log created this
+        // session to "Unassigned". Keep the last known state instead and tell
+        // the user, so a flaky request stays a transient error.
         console.error('Failed to load children:', err);
-        childProfiles = [];
-        unassignedCount = 0;
+        showToast('Could not load profiles — showing last known state');
+        return;
     }
     selectedChild = resolveSelectedChild();
     storeSelectedChild(selectedChild);
@@ -640,6 +645,16 @@ function getTimerState() {
 }
 
 function startTimer(side) {
+    // An active session lives only in localStorage until it is ended, so
+    // overwriting it destroys every segment recorded so far with no way back.
+    // Reaching Start with a timer already running means a mis-tap, not an
+    // intent to discard a feed in progress.
+    const existing = getTimerState();
+    if (existing && existing.active) {
+        showTimerUI();
+        showToast('A feeding is already in progress');
+        return;
+    }
     const state = {
         active: true,
         // The timer belongs to whoever was selected when it started, and keeps
@@ -956,7 +971,9 @@ function initTimer() {
 async function loadLastBreastFeeding() {
     const infoEl = document.getElementById('last-feeding-info');
     try {
-        const feedings = await api.get('/api/feedings?limit=20');
+        // Scoped like every other read: this banner drives the next-feed
+        // decision, so showing a sibling's session here is actively misleading.
+        const feedings = await api.get(`/api/feedings?limit=20${childQuery()}`);
         const now = Date.now();
 
         // Find the most recent breast feeding session. Feedings sharing a session_id
@@ -1787,6 +1804,17 @@ function initEditForm() {
                 if (timestamp && timestamp !== originalTimestamp) {
                     baseBody.timestamp = new Date(timestamp).toISOString();
                 }
+                // This branch hand-builds its bodies instead of going through
+                // buildEditBody, so the Child select — which is rendered for
+                // paired feeds too — has to be read here as well. The router
+                // keys off model_fields_set, so omitting child_id is a no-op
+                // and the reassignment would silently do nothing.
+                const pairedChildEl = document.getElementById('edit-child');
+                if (pairedChildEl) {
+                    baseBody.child_id = pairedChildEl.value
+                        ? parseInt(pairedChildEl.value, 10)
+                        : null;
+                }
                 const leftDur = document.getElementById('edit-left-duration').value;
                 const rightDur = document.getElementById('edit-right-duration').value;
                 const leftBody = { ...baseBody };
@@ -1845,6 +1873,9 @@ function initEditForm() {
 
 /* ===== Calendar Day View ===== */
 let currentDate = new Date();
+// The calendar day the UI was last rendered against. The auto-refresh compares
+// it to the real clock to notice midnight passing on a page left open.
+let lastKnownToday = new Date();
 
 function toDateString(d) {
     const y = d.getFullYear();
@@ -1874,6 +1905,28 @@ function updateCalendarUI() {
     document.getElementById('cal-next').disabled = isToday;
     const pill = document.getElementById('cal-today-pill');
     pill.classList.toggle('hidden', isToday);
+}
+
+/**
+ * Periodic refresh that survives midnight.
+ *
+ * ``currentDate`` is fixed when the page loads, so on a page left open
+ * overnight a plain ``loadDashboard()`` keeps requesting yesterday while the
+ * heading still reads "Today" — and both escape hatches are unavailable,
+ * because ``cal-next`` was disabled and the jump-to-today pill hidden back
+ * when the two dates did agree. Overnight use is exactly when this app is
+ * open, so follow the day forward instead.
+ */
+function refreshDashboard() {
+    const now = new Date();
+    if (!isSameDay(now, lastKnownToday)) {
+        // Only follow the rollover if the user was actually on "today";
+        // someone reviewing an earlier day should stay where they are.
+        if (isSameDay(currentDate, lastKnownToday)) currentDate = now;
+        lastKnownToday = now;
+        updateCalendarUI();
+    }
+    loadDashboard();
 }
 
 function prevDay() {
@@ -2140,5 +2193,5 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     // Auto-refresh dashboard every 60 seconds
-    setInterval(loadDashboard, 60000);
+    setInterval(refreshDashboard, 60000);
 });

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -316,3 +316,53 @@ def test_zero_profiles_export_has_no_child_column(client):
 def test_zero_profiles_children_list_is_empty(client):
     assert client.get("/api/children").json() == []
     assert client.get("/api/children/unassigned").json()["count"] == 0
+
+
+def test_create_rejects_nonexistent_child_id(client):
+    """A log naming a child that does not exist must be refused.
+
+    SQLite foreign keys are off by default, so nothing below the application
+    catches this — and the resulting orphan is unreachable in every view:
+    no child's scoped list matches it, and the unassigned view filters on
+    ``child_id IS NULL``.  Silent, unrecoverable data loss.
+    """
+    for path, payload in (
+        ("/api/diapers", {"type": "pee"}),
+        ("/api/feedings", {"feeding_type": "bottle", "amount": 3.0, "amount_unit": "oz"}),
+        (
+            "/api/medications",
+            {"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"},
+        ),
+        ("/api/temperatures", {"temperature_celsius": 37.2}),
+    ):
+        resp = client.post(path, json={**payload, "child_id": 999})
+        assert resp.status_code == 422, f"{path} accepted a nonexistent child_id"
+
+    assert client.get("/api/children/unassigned").json()["count"] == 0
+
+
+def test_update_rejects_nonexistent_child_id(client):
+    """Reassigning a log to a nonexistent child must be refused too.
+
+    The update path is how a stale client — one holding a profile id deleted
+    in another tab — orphans an *existing* log.
+    """
+    child_id = client.post("/api/children", json={"name": "Theo"}).json()["id"]
+    diaper_id = client.post("/api/diapers", json={"type": "pee", "child_id": child_id}).json()["id"]
+
+    resp = client.put(f"/api/diapers/{diaper_id}", json={"child_id": 424242})
+    assert resp.status_code == 422
+
+    # The original association must survive the rejected update.
+    assert client.get(f"/api/diapers/{diaper_id}").json()["child_id"] == child_id
+
+
+def test_update_to_explicit_null_still_unassigns(client):
+    """Validation must not break the deliberate move back to unassigned."""
+    child_id = client.post("/api/children", json={"name": "Maya"}).json()["id"]
+    created = client.post("/api/diapers", json={"type": "poop", "child_id": child_id})
+    diaper_id = created.json()["id"]
+
+    resp = client.put(f"/api/diapers/{diaper_id}", json={"child_id": None})
+    assert resp.status_code == 200
+    assert resp.json()["child_id"] is None

--- a/tests/test_diapers.py
+++ b/tests/test_diapers.py
@@ -80,3 +80,27 @@ def test_diaper_stats(client):
     assert data["today"] == 2
     assert data["week"] >= 2
     assert data["month"] >= 2
+
+
+def test_diaper_stats_week_boundary_respects_utc_offset(client, monkeypatch):
+    """The week window must be measured in UTC, not local wall clock.
+
+    ``_period_count`` builds its bound from ``datetime.now(local_tz)``, and
+    SQLite drops tzinfo when binding a datetime — so a bound that is not
+    explicitly converted to UTC is compared as local wall clock against
+    UTC-stored rows, silently widening the window by the local offset.
+
+    A diaper logged 7 days *and 2 hours* ago is outside the window at any
+    offset.  Under ``Etc/GMT+5`` (UTC-5) an unconverted bound would shift
+    the cutoff 5 hours earlier and wrongly include it.
+    """
+    from datetime import UTC, datetime, timedelta
+
+    ts = (datetime.now(UTC) - timedelta(days=7, hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    client.post("/api/diapers", json={"type": "pee", "timestamp": ts})
+
+    monkeypatch.setenv("TZ", "Etc/GMT+5")
+
+    resp = client.get("/api/diapers/stats")
+    assert resp.status_code == 200
+    assert resp.json()["week"] == 0

--- a/tests/test_feedings.py
+++ b/tests/test_feedings.py
@@ -342,3 +342,52 @@ def test_migration_adds_session_id_column(setup_db):
             assert resp.json()["today"] == 0
     finally:
         app.dependency_overrides.clear()
+
+
+def test_paired_edit_reassigns_both_records(client):
+    """Editing a paired breast session must move *both* records to the new child.
+
+    The frontend builds this submit body by hand rather than going through
+    ``buildEditBody``, so it has to read the child selector itself.  Because
+    the router keys off ``model_fields_set``, an omitted ``child_id`` is a
+    silent no-op — the user sees "Updated!" while the association is
+    unchanged (see ``test_edit_without_child_id_leaves_association_untouched``
+    in test_children.py for that behaviour on its own).  This asserts the
+    paired path actually sends the field.
+    """
+    maya = client.post("/api/children", json={"name": "Maya"}).json()["id"]
+    theo = client.post("/api/children", json={"name": "Theo"}).json()["id"]
+
+    session_id = "paired-session-1"
+    timestamp = "2026-07-19T12:00:00Z"
+    left = client.post(
+        "/api/feedings",
+        json={
+            "feeding_type": "breast_left",
+            "duration_minutes": 10,
+            "session_id": session_id,
+            "timestamp": timestamp,
+            "child_id": maya,
+        },
+    ).json()
+    right = client.post(
+        "/api/feedings",
+        json={
+            "feeding_type": "breast_right",
+            "duration_minutes": 8,
+            "session_id": session_id,
+            "timestamp": timestamp,
+            "child_id": maya,
+        },
+    ).json()
+
+    # Exactly what the paired submit branch sends once the child is switched.
+    base = {"notes": "", "child_id": theo}
+    for feeding, duration in ((left, 10), (right, 8)):
+        resp = client.put(
+            f"/api/feedings/{feeding['id']}", json={**base, "duration_minutes": duration}
+        )
+        assert resp.status_code == 200
+
+    assert client.get(f"/api/feedings/{left['id']}").json()["child_id"] == theo
+    assert client.get(f"/api/feedings/{right['id']}").json()["child_id"] == theo


### PR DESCRIPTION
Each of these either shows the wrong number or loses data outright. The backend fixes carry regression tests; the frontend ones were verified against the running app, since there is no JS test infrastructure.

Backend:

* _period_count converted only the "today" bound to UTC. SQLite drops tzinfo when binding a datetime, so the week and month bounds were compared as local wall clock against UTC-stored rows, widening the window by the local offset. diaper_stats and medication_stats were wrong at every non-UTC offset while feeding_stats was right, so the dashboard cards disagreed with each other.

* Nothing validated child_id on create or update. SQLite leaves foreign keys off per-connection, so a stale or typo'd id was written happily, and the resulting orphan was unreachable in every view: no child's scoped list matched it, and the unassigned view filters on child_id IS NULL. Silent, unrecoverable loss. Adds validate_child_id across all four create and all four update paths, plus PRAGMA foreign_keys=ON as a backstop for writes that bypass it. (delete_child already nulls its logs in application code, so the inert ondelete clause was not load-bearing.)

Frontend:

* startTimer overwrote a running session. An active feed lives only in localStorage until it is ended, so a mis-tap on Start discarded every segment recorded so far with no way back.

* The 60s auto-refresh never updated the calendar, so past midnight on a page left open the dashboard requested yesterday under a "Today" heading with both escape hatches disabled. Overnight use is exactly when this app is open. refreshDashboard now follows the day forward, while leaving a deliberately navigated date alone.

* A failed /api/children load reset childProfiles to empty, which is indistinguishable from a genuine zero-profile install -- and then persisted it, clearing the stored selection and routing every log created that session to Unassigned. It now keeps the last known state and surfaces the error.

* The feeding modal's "last session" banner was unscoped and could show a sibling's feed, which directly drives the next-feed decision.

* The paired breast-feeding edit hand-builds its request body and never read the child selector. Since the router keys off model_fields_set, the omitted child_id was a no-op: the user saw "Updated!" while the association stayed put.