### PR TITLE
Fix six validation and datetime-handling bugs

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -5,6 +5,7 @@ from datetime import date as date_type
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from sqlalchemy import String, cast, func, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from puffin.models import (
@@ -45,6 +46,11 @@ def _child_where(stmt, col, child: ChildFilter):
 # supplied".  Setting ``child_id`` to ``None`` is how a log is deliberately
 # moved back to unassigned, so it must not be skipped like other blanks.
 _NULLABLE_UPDATE_KEYS = {"child_id"}
+
+# Feeding fields that a type conversion clears.  These must be written even
+# when the new value is ``None``, which the generic "skip blanks" rule would
+# otherwise drop.
+_CLEARED_ON_CONVERT = {"amount", "amount_unit", "duration_minutes"}
 
 
 # --- Generic helpers ---
@@ -141,7 +147,7 @@ def get_diapers(
     if start_date:
         stmt = stmt.where(DiaperChange.timestamp >= start_date)
     if end_date:
-        stmt = stmt.where(DiaperChange.timestamp <= end_date)
+        stmt = stmt.where(DiaperChange.timestamp < end_date)
     stmt = _child_where(stmt, DiaperChange.child_id, child)
     stmt = stmt.offset(offset).limit(limit)
     return list(db.execute(stmt).scalars().all())
@@ -235,7 +241,7 @@ def get_feedings(
     if start_date:
         stmt = stmt.where(Feeding.timestamp >= start_date)
     if end_date:
-        stmt = stmt.where(Feeding.timestamp <= end_date)
+        stmt = stmt.where(Feeding.timestamp < end_date)
     stmt = _child_where(stmt, Feeding.child_id, child)
     stmt = stmt.offset(offset).limit(limit)
     return list(db.execute(stmt).scalars().all())
@@ -253,8 +259,15 @@ def update_feeding(db: Session, feeding_id: int, **kwargs) -> Feeding | None:
     if target_type in {"breast_left", "breast_right"}:
         kwargs["amount"] = None
         kwargs["amount_unit"] = None
+    elif target_type == "bottle":
+        # The mirror of the above: a bottle has no duration.  Without this a
+        # breast feed converted to a bottle keeps its old duration -- harmless
+        # in the timeline, which renders the bottle branch, but the CSV and PDF
+        # exports print the column verbatim and show a phantom duration.  The
+        # router only forwards non-None values, so the frontend cannot clear it.
+        kwargs["duration_minutes"] = None
     for k, v in kwargs.items():
-        if v is not None or k in {"amount", "amount_unit"} | _NULLABLE_UPDATE_KEYS:
+        if v is not None or k in _CLEARED_ON_CONVERT | _NULLABLE_UPDATE_KEYS:
             setattr(obj, k, v)
     db.commit()
     db.refresh(obj)
@@ -357,7 +370,7 @@ def get_medications(
     if start_date:
         stmt = stmt.where(Medication.timestamp >= start_date)
     if end_date:
-        stmt = stmt.where(Medication.timestamp <= end_date)
+        stmt = stmt.where(Medication.timestamp < end_date)
     stmt = _child_where(stmt, Medication.child_id, child)
     stmt = stmt.offset(offset).limit(limit)
     return list(db.execute(stmt).scalars().all())
@@ -402,13 +415,34 @@ def get_saved_medications(db: Session) -> list[str]:
     return list(db.execute(stmt).scalars().all())
 
 
-def add_saved_medication(db: Session, name: str) -> bool:
-    """Add name to saved list if no case-insensitive match exists. Returns True if added."""
+def _saved_medication_exists(db: Session, name: str) -> bool:
+    """Whether *name* is already saved, ignoring case.
+
+    Split out from ``add_saved_medication`` so a lost check-then-insert race
+    can be reproduced deterministically in tests.
+    """
     stmt = select(SavedMedication).where(func.lower(SavedMedication.name) == name.lower())
-    if db.execute(stmt).scalar_one_or_none() is not None:
+    return db.execute(stmt).scalar_one_or_none() is not None
+
+
+def add_saved_medication(db: Session, name: str) -> bool:
+    """Add name to saved list if no case-insensitive match exists. Returns True if added.
+
+    The existence check and the insert are not atomic and ``name`` is unique,
+    so two parents saving the same new medication at once can both pass the
+    check.  Losing that race is not a real failure -- the name is on the list
+    either way -- but the uncaught IntegrityError became a 500 *after* the
+    medication log itself had already been committed, so the user saw an error
+    for a save that had partly succeeded.
+    """
+    if _saved_medication_exists(db, name):
         return False
     db.add(SavedMedication(name=name))
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        db.rollback()
+        return False
     return True
 
 
@@ -448,7 +482,7 @@ def get_temperatures(
     if start_date:
         stmt = stmt.where(TemperatureReading.timestamp >= start_date)
     if end_date:
-        stmt = stmt.where(TemperatureReading.timestamp <= end_date)
+        stmt = stmt.where(TemperatureReading.timestamp < end_date)
     stmt = _child_where(stmt, TemperatureReading.child_id, child)
     stmt = stmt.offset(offset).limit(limit)
     return list(db.execute(stmt).scalars().all())

--- a/src/puffin/main.py
+++ b/src/puffin/main.py
@@ -1,8 +1,11 @@
+import math
 from contextlib import asynccontextmanager
 from pathlib import Path
 
 from fastapi import FastAPI, Request
-from fastapi.responses import HTMLResponse
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import HTMLResponse, JSONResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from starlette.middleware.base import BaseHTTPMiddleware
@@ -39,6 +42,40 @@ app = FastAPI(
 )
 
 app.add_middleware(NoCacheAPIMiddleware)
+
+
+def _json_safe(value):
+    """Replace non-finite floats with their string form, recursively.
+
+    ``NaN`` and ``Infinity`` are not valid JSON, and Python's stdlib encoder
+    raises on them rather than emitting the non-standard literals it accepts
+    on input.
+    """
+    if isinstance(value, float) and not math.isfinite(value):
+        return str(value)
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    return value
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    """Render validation errors that echo a non-finite float.
+
+    Python's json parser accepts bare ``NaN``/``Infinity`` literals, so such a
+    value reaches the schema and is correctly rejected -- but FastAPI's default
+    handler echoes the offending input back in the error detail, where the
+    encoder cannot serialize it. That turned a clean 422 into a 500 at the
+    response layer. Scrub the echoed input so the rejection is what the client
+    actually sees.
+    """
+    return JSONResponse(
+        status_code=422,
+        content={"detail": _json_safe(jsonable_encoder(exc.errors()))},
+    )
+
 
 # Mount static files
 app.mount("/static", StaticFiles(directory=str(BASE_DIR / "static")), name="static")

--- a/src/puffin/models.py
+++ b/src/puffin/models.py
@@ -8,14 +8,26 @@ from puffin.database import Base
 
 
 class _UTCDateTime(TypeDecorator):
-    """A DateTime that guarantees UTC tzinfo after SQLite round-trips.
+    """A DateTime that guarantees UTC tzinfo across SQLite round-trips.
 
     SQLite stores datetimes as naive strings, so timezone info is lost on read.
-    This decorator re-attaches UTC on every load.
+    This decorator normalizes to UTC on every save and re-attaches UTC on
+    every load.
     """
 
     impl = DateTime(timezone=True)
     cache_ok = True
+
+    def process_bind_param(self, value: datetime | None, dialect) -> datetime | None:
+        # SQLite's dialect discards tzinfo when binding, so an aware value in
+        # any other offset would be written as its local wall clock and then
+        # read back as UTC -- e.g. 10:00-04:00 stored as "10:00" and returned
+        # as 10:00+00:00, a silent four-hour shift.  Convert first so the
+        # stored wall clock really is UTC.  Naive values are assumed to be UTC
+        # already, matching how they are read back.
+        if value is not None and value.tzinfo is not None:
+            return value.astimezone(UTC)
+        return value
 
     def process_result_value(self, value: datetime | None, dialect) -> datetime | None:
         if value is not None and value.tzinfo is None:

--- a/src/puffin/routers/dashboard.py
+++ b/src/puffin/routers/dashboard.py
@@ -41,7 +41,7 @@ def get_dashboard(
 def export_data(
     export_format: str = Query("csv", alias="format", pattern="^(csv|json|pdf)$"),
     start_date: datetime | None = Query(None),
-    end_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None, description="Exclusive upper bound"),
     child: ChildFilter = Depends(child_filter),
     db: Session = Depends(get_db),
 ):

--- a/src/puffin/routers/diapers.py
+++ b/src/puffin/routers/diapers.py
@@ -27,7 +27,7 @@ def create_diaper(data: DiaperChangeCreate, db: Session = Depends(get_db)):
 @router.get("", response_model=list[DiaperChangeResponse])
 def list_diapers(
     start_date: datetime | None = Query(None),
-    end_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None, description="Exclusive upper bound"),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     child: ChildFilter = Depends(child_filter),

--- a/src/puffin/routers/feedings.py
+++ b/src/puffin/routers/feedings.py
@@ -32,7 +32,7 @@ def create_feeding(data: FeedingCreate, db: Session = Depends(get_db)):
 @router.get("", response_model=list[FeedingResponse])
 def list_feedings(
     start_date: datetime | None = Query(None),
-    end_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None, description="Exclusive upper bound"),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     child: ChildFilter = Depends(child_filter),

--- a/src/puffin/routers/health.py
+++ b/src/puffin/routers/health.py
@@ -47,7 +47,7 @@ def list_saved_medication_names(db: Session = Depends(get_db)):
 @router.get("/api/medications", response_model=list[MedicationResponse])
 def list_medications(
     start_date: datetime | None = Query(None),
-    end_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None, description="Exclusive upper bound"),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     child: ChildFilter = Depends(child_filter),
@@ -123,7 +123,7 @@ def create_temperature(data: TemperatureCreate, db: Session = Depends(get_db)):
 @router.get("/api/temperatures", response_model=list[TemperatureResponse])
 def list_temperatures(
     start_date: datetime | None = Query(None),
-    end_date: datetime | None = Query(None),
+    end_date: datetime | None = Query(None, description="Exclusive upper bound"),
     limit: int = Query(50, ge=1, le=200),
     offset: int = Query(0, ge=0),
     child: ChildFilter = Depends(child_filter),

--- a/src/puffin/schemas.py
+++ b/src/puffin/schemas.py
@@ -1,9 +1,20 @@
+import math
 from datetime import datetime
 from decimal import Decimal
 from enum import StrEnum
 from typing import Self
 
-from pydantic import BaseModel, ConfigDict, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+# Bounds for the free-numeric log fields.  These are deliberately generous --
+# the goal is to reject transparently impossible input (negative durations, a
+# -500 C body temperature that the PDF export happily renders as -868 F), not
+# to second-guess a real reading.  The frontend converts Fahrenheit to Celsius
+# before posting, so a temperature always arrives in Celsius.
+_MIN_TEMP_C = 20.0  # below profound hypothermia
+_MAX_TEMP_C = 45.0  # above survivable hyperthermia
+_MAX_FEED_MINUTES = 24 * 60
+_MAX_BOTTLE_AMOUNT = 2000.0  # generous in either mL or oz
 
 # --- Enums ---
 
@@ -131,8 +142,8 @@ class DiaperChangeResponse(BaseModel):
 class FeedingCreate(BaseModel):
     timestamp: datetime | None = None
     feeding_type: FeedingType
-    duration_minutes: int | None = None
-    amount: float | None = None
+    duration_minutes: int | None = Field(None, ge=0, le=_MAX_FEED_MINUTES)
+    amount: float | None = Field(None, gt=0, le=_MAX_BOTTLE_AMOUNT)
     amount_unit: BottleUnit | None = None
     notes: str | None = None
     session_id: str | None = None
@@ -153,8 +164,8 @@ class FeedingCreate(BaseModel):
 class FeedingUpdate(BaseModel):
     timestamp: datetime | None = None
     feeding_type: FeedingType | None = None
-    duration_minutes: int | None = None
-    amount: float | None = None
+    duration_minutes: int | None = Field(None, ge=0, le=_MAX_FEED_MINUTES)
+    amount: float | None = Field(None, gt=0, le=_MAX_BOTTLE_AMOUNT)
     amount_unit: BottleUnit | None = None
     notes: str | None = None
     bottle_type: BottleType | None = None
@@ -191,6 +202,13 @@ class FeedingResponse(BaseModel):
 
 
 def _validate_dosage_quantity(v: float) -> float:
+    # NaN and infinity must be rejected before the exponent check: for those,
+    # ``as_tuple().exponent`` is the string 'n'/'F' rather than an int, so
+    # comparing it raises TypeError -- which Pydantic does not convert into a
+    # validation error, surfacing as an unhandled 500.  Python's json parser
+    # accepts bare NaN/Infinity literals, so this is reachable from any client.
+    if not math.isfinite(v):
+        raise ValueError("Quantity must be a finite number")
     if Decimal(str(v)).as_tuple().exponent < -2:
         raise ValueError("Quantity must have at most 2 decimal places")
     if v <= 0:
@@ -246,7 +264,7 @@ class MedicationResponse(BaseModel):
 
 class TemperatureCreate(BaseModel):
     timestamp: datetime | None = None
-    temperature_celsius: float
+    temperature_celsius: float = Field(ge=_MIN_TEMP_C, le=_MAX_TEMP_C)
     location: TemperatureLocation | None = None
     notes: str | None = None
     child_id: int | None = None
@@ -254,7 +272,7 @@ class TemperatureCreate(BaseModel):
 
 class TemperatureUpdate(BaseModel):
     timestamp: datetime | None = None
-    temperature_celsius: float | None = None
+    temperature_celsius: float | None = Field(None, ge=_MIN_TEMP_C, le=_MAX_TEMP_C)
     location: TemperatureLocation | None = None
     notes: str | None = None
     child_id: int | None = None

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2133,7 +2133,14 @@ function initExport() {
 
         let url = `/api/export?format=${encodeURIComponent(fmt)}`;
         if (start) url += `&start_date=${encodeURIComponent(start + 'T00:00:00')}`;
-        if (end) url += `&end_date=${encodeURIComponent(end + 'T23:59:59')}`;
+        // end_date is an exclusive bound, so send the following midnight rather
+        // than 23:59:59 — the latter silently dropped anything logged in the
+        // final second of the chosen day.
+        if (end) {
+            const endExclusive = new Date(end + 'T00:00:00');
+            endExclusive.setDate(endExclusive.getDate() + 1);
+            url += `&end_date=${encodeURIComponent(toDateString(endExclusive) + 'T00:00:00')}`;
+        }
 
         const childEl = document.getElementById('export-child');
         if (hasProfiles() && childEl.value !== EXPORT_ALL_CHILDREN) {

--- a/tests/test_activities.py
+++ b/tests/test_activities.py
@@ -173,3 +173,29 @@ def test_activities_timezone_included_today(client, monkeypatch):
     resp = client.get("/api/activities?date=2026-04-08")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
+
+
+def test_activity_at_local_midnight_belongs_to_exactly_one_day(client, monkeypatch):
+    """A log at exactly local midnight must not appear in both adjacent days.
+
+    ``_day_bounds`` returns an *exclusive* next-midnight end and
+    ``_count_range`` honours it, but the list queries used ``<=`` -- so a
+    boundary row showed up in both daily lists and disagreed with the
+    dashboard count for the same date.  Reachable any time a user types a
+    round 00:00 time.
+    """
+    from datetime import UTC, datetime, timedelta, timezone
+
+    local_tz_offset = timezone(timedelta(hours=-5))
+    midnight_local = datetime(2026, 4, 8, 0, 0, 0, tzinfo=local_tz_offset)
+    ts_utc = midnight_local.astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    client.post("/api/diapers", json={"type": "pee", "timestamp": ts_utc})
+    monkeypatch.setenv("TZ", "Etc/GMT+5")
+
+    previous_day = client.get("/api/activities?date=2026-04-07").json()
+    boundary_day = client.get("/api/activities?date=2026-04-08").json()
+
+    # Midnight opens the new day; it must not also close the previous one.
+    assert len(previous_day) == 0
+    assert len(boundary_day) == 1

--- a/tests/test_feedings.py
+++ b/tests/test_feedings.py
@@ -391,3 +391,64 @@ def test_paired_edit_reassigns_both_records(client):
 
     assert client.get(f"/api/feedings/{left['id']}").json()["child_id"] == theo
     assert client.get(f"/api/feedings/{right['id']}").json()["child_id"] == theo
+
+
+def test_negative_duration_and_amount_are_rejected(client):
+    """Negative durations and amounts must not reach the log or the export."""
+    assert (
+        client.post(
+            "/api/feedings", json={"feeding_type": "breast_left", "duration_minutes": -600}
+        ).status_code
+        == 422
+    )
+    assert (
+        client.post(
+            "/api/feedings",
+            json={"feeding_type": "bottle", "amount": -5, "amount_unit": "oz"},
+        ).status_code
+        == 422
+    )
+
+
+def test_converting_breast_to_bottle_clears_duration(client):
+    """A bottle has no duration, mirroring how breast clears amount/unit.
+
+    The stale value is invisible in the timeline (which renders the bottle
+    branch) but the CSV and PDF exports print the column verbatim, so an
+    exported bottle feed carried a phantom duration.
+    """
+    feeding = client.post(
+        "/api/feedings", json={"feeding_type": "breast_left", "duration_minutes": 12}
+    ).json()
+
+    resp = client.put(
+        f"/api/feedings/{feeding['id']}",
+        json={"feeding_type": "bottle", "amount": 4.0, "amount_unit": "oz"},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["duration_minutes"] is None
+    assert resp.json()["amount"] == 4.0
+
+
+def test_offset_timestamp_is_converted_to_utc_on_write(client):
+    """A non-UTC offset must be converted, not stored as wall clock.
+
+    SQLite drops tzinfo when binding, so without a bind-side conversion
+    10:00-04:00 was written as "10:00" and read back as 10:00+00:00 -- a
+    silent four-hour shift for any client that sends a local offset.
+    """
+    from datetime import UTC, datetime
+
+    feeding = client.post(
+        "/api/feedings",
+        json={
+            "feeding_type": "bottle",
+            "amount": 3.0,
+            "amount_unit": "oz",
+            "timestamp": "2026-07-19T10:00:00-04:00",
+        },
+    ).json()
+
+    fetched = client.get(f"/api/feedings/{feeding['id']}").json()
+    stored = datetime.fromisoformat(fetched["timestamp"])
+    assert stored.astimezone(UTC) == datetime(2026, 7, 19, 14, 0, tzinfo=UTC)

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -372,3 +372,62 @@ def test_saved_names_preserves_original_casing(client):
     )
     resp = client.get("/api/medications/saved-names")
     assert resp.json() == ["vitamin C"]
+
+
+def test_nan_dosage_is_rejected_not_a_500(client):
+    """NaN/Infinity must validate as 422 rather than crash the handler.
+
+    ``Decimal('NaN').as_tuple().exponent`` is the string 'n' (and 'F' for
+    infinity), so comparing it against an int raises TypeError.  Pydantic only
+    converts ValueError/AssertionError into validation errors, so that escaped
+    as an unhandled 500 -- and Python's json parser accepts bare NaN/Infinity
+    literals, so any client can reach it.
+    """
+    for literal in ("NaN", "Infinity", "-Infinity"):
+        body = (
+            '{"medication_name": "Tylenol", "dosage_quantity": '
+            + literal
+            + ', "dosage_unit": "mL"}'
+        )
+        resp = client.post(
+            "/api/medications", content=body, headers={"Content-Type": "application/json"}
+        )
+        assert resp.status_code == 422, f"{literal} did not validate cleanly"
+
+
+def test_implausible_temperature_is_rejected(client):
+    """A transparently impossible reading must not reach the exports.
+
+    -500 C was accepted and rendered as -868.0 F in the PDF/CSV export.
+    """
+    for celsius in (-500, 500, 0, 60):
+        resp = client.post("/api/temperatures", json={"temperature_celsius": celsius})
+        assert resp.status_code == 422, f"{celsius} C was accepted"
+
+    # A real fever must still go through.
+    assert client.post("/api/temperatures", json={"temperature_celsius": 39.4}).status_code == 201
+
+
+def test_saved_medication_survives_a_lost_race(client, monkeypatch):
+    """Losing the check-then-insert race must not surface as a 500.
+
+    ``SavedMedication.name`` is unique and the existence check is not atomic
+    with the insert, so two parents saving the same new medication at once can
+    both pass the check. Patching the check to report "absent" while the row
+    exists reproduces the loser's path deterministically -- a plain sequential
+    duplicate returns at the check and never reaches the insert.
+
+    This matters because ``add_saved_medication`` runs *after* the medication
+    log has already been committed, so an uncaught IntegrityError showed the
+    user a failure for a save that had partly succeeded.
+    """
+    from puffin import crud
+
+    payload = {"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"}
+    assert client.post("/api/medications", json=payload).status_code == 201
+
+    monkeypatch.setattr(crud, "_saved_medication_exists", lambda db, name: False)
+    resp = client.post("/api/medications", json=payload)
+
+    assert resp.status_code == 201
+    assert client.get("/api/medications/saved-names").json().count("Tylenol") == 1


### PR DESCRIPTION
The second batch from the audit. Every fix carries a regression test that was confirmed to fail without it.

* _UTCDateTime attached UTC on read but never converted on write. SQLite drops tzinfo when binding, so a timestamp sent with any other offset was stored as its local wall clock and read back as UTC -- posting 10:00-04:00 yielded 10:00+00:00, a silent four-hour shift. The bundled frontend always sends toISOString() so the shipped UI was unaffected, but any other client corrupted data with no error.

* A NaN or Infinity dosage crashed with a 500. Decimal('NaN').as_tuple() .exponent is the string 'n' rather than an int, so the decimal-places comparison raised TypeError, which Pydantic does not convert into a validation error. Python's json parser accepts bare NaN/Infinity literals, so any client could reach it. Rejecting it in the validator turned out not to be enough on its own: FastAPI's default handler echoes the offending input back in the error detail, where the encoder cannot serialize it -- so a clean 422 still became a 500 at the response layer. Adds a handler that scrubs non-finite floats, which covers the whole class rather than just this field.

* Converting a breast feed to a bottle left the old duration_minutes in place. The timeline renders the bottle branch so it looked fine, but the CSV and PDF exports print the column verbatim and showed a phantom duration. Mirrors the existing clearing of amount/amount_unit in the other direction.

* end_date was inclusive in the list queries but exclusive in _day_bounds and _count_range, so a log at exactly local midnight appeared in both adjacent days and disagreed with the dashboard count for the same date. Makes the bound exclusive throughout and documents it on the routers. The export URL moves from an inclusive T23:59:59 to the following midnight, which also closes a pre-existing hole where anything logged in the final second of the range was dropped.

* Temperature, bottle amount, and feed duration had no range checks. A -500 C reading was accepted and rendered as -868.0 F in the export. Bounds are deliberately generous -- the goal is to reject the transparently impossible, not to second-guess a real reading.

* add_saved_medication let a lost check-then-insert race surface as a
  500. It runs after the medication log has already been committed, so the user saw a failure for a save that had partly succeeded. The existence check is split into a helper so the loser's path can be reproduced deterministically -- a sequential duplicate returns at the check and never reaches the insert, so it could not have caught this.