### PR TITLE
Add SQLite backups: pre-migration snapshots and an on-demand command

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ dev          # start FastAPI dev server on port 8000
 | `test-js` | Run JS tests only (Node's built-in `node:test`) |
 | `install-deps` | Install dependencies with uv |
 | `seed` | Generate 14 days of demo data |
+| `backup` | Snapshot the database into `<db-dir>/backups` |
 
 ### For AI Agents
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ Then open [http://localhost:8000](http://localhost:8000).
 
 - `PUFFIN_DB_PATH` — Path to the SQLite database file (default: `/data/puffin.db`). Normally you don't need to change this.
 - `TZ` — IANA timezone name (e.g. `America/New_York`) used to decide where one day ends and the next begins (default: `UTC`). **Set this to your local timezone.** Without it, an evening log west of UTC is counted as tomorrow — a diaper logged at 21:10 US Central lands on the next UTC day, so it won't show up in today's dashboard counts or timeline until midnight UTC. An unrecognized value falls back to UTC.
+- `PUFFIN_BACKUP_KEEP` — How many database snapshots to retain per backup (default: `10`). Set to `0` to keep every snapshot.
+
+## Backups
+
+All your data is a single SQLite file, so there are two safety nets:
+
+- **Automatic pre-migration snapshots.** On every startup, before any schema migration runs, the database is copied to `<db-dir>/backups/` (i.e. `/data/backups` in Docker). Migrations rewrite tables in place, so this gives you a rollback point for the one operation most likely to damage data. Old snapshots are pruned to `PUFFIN_BACKUP_KEEP`.
+- **On-demand backups.** Run `backup` (in `devenv shell`) or `python -m puffin.backup` to snapshot on demand. Wire it to cron or a systemd timer for regular copies, e.g. a daily line in the container host's crontab:
+
+  ```cron
+  0 3 * * * docker exec puffin python -m puffin.backup
+  ```
+
+To restore, stop the app and copy the chosen `backups/*.db` file back over `puffin.db`.
+
+> **Off-box copies:** these snapshots live on the same disk/volume as the database, so they protect against bad migrations and logical corruption but **not** against losing the disk. For disaster protection, periodically copy `backups/` elsewhere, or replicate the database off-box with a tool like [Litestream](https://litestream.io/).
 
 ## Development
 
@@ -79,8 +95,9 @@ Run these commands inside `devenv shell`:
 - `lint` — Run ruff linter
 - `lint-fix` — Run ruff linter with auto-fix
 - `format` — Run ruff formatter
-- `test` — Run pytest
+- `test` — Run all tests (Python + JS)
 - `seed` — Generate 14 days of realistic demo data
+- `backup` — Snapshot the database into `<db-dir>/backups`
 
 See `AGENTS.md` for the complete command reference including background/agent-friendly variants.
 

--- a/devenv.nix
+++ b/devenv.nix
@@ -102,6 +102,7 @@ in
 
     # Data commands
     seed.exec = "uv run python -m puffin.seed";
+    backup.exec = "uv run python -m puffin.backup";
   };
 
   enterShell = ''
@@ -132,6 +133,7 @@ in
     echo ""
     echo "Data commands:"
     echo "  seed             - Generate 14 days of demo data"
+    echo "  backup           - Snapshot the database into <db-dir>/backups"
     echo ""
     echo "Other commands:"
     echo "  install-deps     - Install dependencies with uv"

--- a/src/puffin/backup.py
+++ b/src/puffin/backup.py
@@ -1,0 +1,114 @@
+"""SQLite backup helpers.
+
+The whole database is a single file holding irreplaceable family records, so
+two cheap safety nets guard it:
+
+* a snapshot taken automatically before every migration run (``init_db``),
+  since migrations rewrite tables in place on the one live copy; and
+* an on-demand backup (``python -m puffin.backup``) to wire to cron/systemd.
+
+Both use SQLite's online backup API, which produces a consistent copy even if
+the database is being written concurrently, and both land in a ``backups/``
+directory beside the database. That protects against a bad migration or logical
+corruption; it does **not** protect against losing the disk itself, since the
+copies share it -- see README for off-box replication.
+"""
+
+import logging
+import os
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+logger = logging.getLogger("uvicorn.error")
+
+# How many snapshots to retain per database. Override with PUFFIN_BACKUP_KEEP;
+# 0 or negative disables pruning (keep everything).
+DEFAULT_KEEP = 10
+
+
+def _keep_count() -> int:
+    raw = os.environ.get("PUFFIN_BACKUP_KEEP")
+    if raw is None:
+        return DEFAULT_KEEP
+    try:
+        return int(raw)
+    except ValueError:
+        return DEFAULT_KEEP
+
+
+def _backup_dir(db_path: Path) -> Path:
+    return db_path.parent / "backups"
+
+
+def _prune(backups: Path, stem: str, keep: int) -> None:
+    """Keep only the newest *keep* snapshots for *stem*.
+
+    Filenames are timestamped with a fixed-width, zero-padded stamp, so
+    lexical order is chronological order.
+    """
+    if keep <= 0:
+        return
+    snaps = sorted(backups.glob(f"{stem}-*.db"))
+    for old in snaps[:-keep]:
+        old.unlink(missing_ok=True)
+
+
+def backup_database(db_path, *, reason: str = "manual", keep: int | None = None) -> Path | None:
+    """Write a consistent snapshot of *db_path* into its ``backups/`` dir.
+
+    Returns the snapshot path, or ``None`` when there is nothing to back up
+    (the file is missing or empty, i.e. a fresh install). *reason* is embedded
+    in the filename so ``pre-migration`` and ``manual`` copies are
+    distinguishable. Never raises on backup failure -- a failed backup must not
+    take down startup -- but logs it.
+    """
+    db_path = Path(db_path)
+    if not db_path.exists() or db_path.stat().st_size == 0:
+        return None
+
+    if keep is None:
+        keep = _keep_count()
+
+    backups = _backup_dir(db_path)
+    backups.mkdir(parents=True, exist_ok=True)
+    # Microseconds keep the stamp unique when two snapshots land in one second
+    # (e.g. a manual backup right after the pre-migration one).
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%S_%fZ")
+    dest = backups / f"{db_path.stem}-{stamp}-{reason}.db"
+
+    try:
+        src = sqlite3.connect(str(db_path))
+        try:
+            dst = sqlite3.connect(str(dest))
+            try:
+                with dst:
+                    src.backup(dst)
+            finally:
+                dst.close()
+        finally:
+            src.close()
+    except sqlite3.Error:
+        logger.exception("Database backup to %s failed", dest)
+        dest.unlink(missing_ok=True)
+        return None
+
+    _prune(backups, db_path.stem, keep)
+    logger.info("Database backed up to %s (reason=%s)", dest, reason)
+    return dest
+
+
+def main() -> None:
+    # Imported lazily so this module has no import-time dependency on database
+    # (which imports this one).
+    from puffin.database import DB_PATH
+
+    dest = backup_database(DB_PATH, reason="manual")
+    if dest is None:
+        print("No database to back up yet.")
+    else:
+        print(f"Backed up to {dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -249,5 +249,12 @@ def _run_migrations(bind=None) -> None:
 def init_db():
     """Create all tables, disposing stale connections first."""
     engine.dispose()
+    # Snapshot the existing database before migrations rewrite it in place, so a
+    # failed or wrong migration can be rolled back. No-op on a fresh install.
+    # Imported here (not at module top) to avoid a circular import: backup's CLI
+    # reads DB_PATH from this module.
+    from puffin.backup import backup_database
+
+    backup_database(DB_PATH, reason="pre-migration")
     Base.metadata.create_all(bind=engine)
     _run_migrations()

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,107 @@
+import sqlite3
+
+from puffin.backup import backup_database
+
+
+def _make_db(path, rows):
+    conn = sqlite3.connect(str(path))
+    conn.execute("CREATE TABLE feedings (id INTEGER PRIMARY KEY, note TEXT)")
+    conn.executemany("INSERT INTO feedings (note) VALUES (?)", [(r,) for r in rows])
+    conn.commit()
+    conn.close()
+
+
+def _read_notes(path):
+    conn = sqlite3.connect(str(path))
+    try:
+        return [r[0] for r in conn.execute("SELECT note FROM feedings ORDER BY id")]
+    finally:
+        conn.close()
+
+
+def test_backup_copies_data_consistently(tmp_path):
+    db = tmp_path / "puffin.db"
+    _make_db(db, ["morning feed", "afternoon feed"])
+
+    dest = backup_database(db, reason="manual")
+
+    assert dest is not None
+    assert dest.parent == tmp_path / "backups"
+    assert "manual" in dest.name
+    # The snapshot holds exactly the source data.
+    assert _read_notes(dest) == ["morning feed", "afternoon feed"]
+
+
+def test_backup_is_a_point_in_time_copy(tmp_path):
+    """Writing to the source after a backup must not change the backup."""
+    db = tmp_path / "puffin.db"
+    _make_db(db, ["first"])
+
+    dest = backup_database(db, reason="pre-migration")
+
+    conn = sqlite3.connect(str(db))
+    conn.execute("INSERT INTO feedings (note) VALUES ('second')")
+    conn.commit()
+    conn.close()
+
+    assert _read_notes(dest) == ["first"], "the snapshot is frozen at backup time"
+    assert _read_notes(db) == ["first", "second"]
+
+
+def test_reason_appears_in_filename(tmp_path):
+    db = tmp_path / "puffin.db"
+    _make_db(db, ["x"])
+
+    pre = backup_database(db, reason="pre-migration")
+    manual = backup_database(db, reason="manual")
+
+    assert "pre-migration" in pre.name
+    assert "manual" in manual.name
+    assert pre.name != manual.name, "microsecond stamp keeps same-second backups distinct"
+
+
+def test_missing_database_is_a_noop(tmp_path):
+    assert backup_database(tmp_path / "absent.db") is None
+    assert not (tmp_path / "backups").exists()
+
+
+def test_empty_database_is_a_noop(tmp_path):
+    db = tmp_path / "puffin.db"
+    db.touch()  # zero bytes -- a fresh install with nothing worth keeping
+
+    assert backup_database(db) is None
+
+
+def test_pruning_keeps_only_the_newest(tmp_path):
+    db = tmp_path / "puffin.db"
+    _make_db(db, ["x"])
+
+    created = [backup_database(db, reason="manual", keep=3) for _ in range(5)]
+
+    remaining = sorted((tmp_path / "backups").glob("puffin-*.db"))
+    assert len(remaining) == 3, "only the retention count survives"
+    # The three newest are the ones kept.
+    assert {p.name for p in remaining} == {p.name for p in created[-3:]}
+
+
+def test_keep_zero_disables_pruning(tmp_path):
+    db = tmp_path / "puffin.db"
+    _make_db(db, ["x"])
+
+    for _ in range(4):
+        backup_database(db, reason="manual", keep=0)
+
+    assert len(list((tmp_path / "backups").glob("puffin-*.db"))) == 4
+
+
+def test_backup_failure_returns_none_without_raising(tmp_path, monkeypatch):
+    """A backup error must never take down the caller (startup)."""
+    db = tmp_path / "puffin.db"
+    _make_db(db, ["x"])
+
+    def boom(*args, **kwargs):
+        raise sqlite3.OperationalError("disk full")
+
+    monkeypatch.setattr(sqlite3, "connect", boom)
+    # Must swallow the error and report failure, not propagate it.
+    assert backup_database(db) is None


### PR DESCRIPTION
The whole database is a single file of irreplaceable family records, with no backups, and init_db runs the migration logic on every startup -- including destructive table rewrites (DROP TABLE feedings) -- against that one live copy. A failed or wrong migration had nothing to roll back to.

Adds two safety nets in src/puffin/backup.py, both using SQLite's online backup API (a consistent copy even under concurrent writes), landing in a backups/ dir beside the database (so /data/backups in Docker, inside the persisted volume):

* An automatic pre-migration snapshot taken in init_db before create_all and _run_migrations touch anything. No-op on a fresh install; failures are logged and swallowed so a backup problem can't take down startup.
* An on-demand backup, `python -m puffin.backup` (devenv: `backup`), to wire to cron or a systemd timer.

Snapshots are timestamped (microsecond precision, so same-second copies don't collide) and pruned to PUFFIN_BACKUP_KEEP (default 10; 0 keeps all).

Because the copies share the database's disk, they guard against bad migrations and logical corruption but not disk loss; the README documents copying backups/ off-box or replicating with Litestream for that.

Covered by tests/test_backup.py: copy consistency, point-in-time freezing, the fresh-install no-op, pruning, and that a backup failure returns None rather than raising. Each was confirmed to fail with the logic reverted.