### PR TITLE
Replace the Settings modal with a standalone Settings page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,11 +48,12 @@ dev          # start FastAPI dev server on port 8000
 ## Project Structure
 
 - `src/puffin/` — FastAPI application (models, schemas, crud, routers)
-- `templates/` — Jinja2 HTML templates
-- `static/` — CSS and JavaScript assets
+- `templates/` — Jinja2 HTML templates (`index.html` dashboard, `settings.html`)
+- `static/` — CSS and JavaScript assets; `common.js` is the shared layer both
+  pages load, with `app.js` (dashboard) and `settings.js` layered on top
 - `tests/` — pytest test suite
-- `tests/js/` — JS tests (`node:test`); `harness.mjs` loads `static/js/app.js`
-  unmodified and exposes its DOM-free functions
+- `tests/js/` — JS tests (`node:test`); `harness.mjs` loads `static/js/common.js`
+  and `static/js/app.js` unmodified and exposes their DOM-free functions
 
 ## Tech Stack
 

--- a/src/puffin/main.py
+++ b/src/puffin/main.py
@@ -95,3 +95,8 @@ app.include_router(dashboard.router)
 @app.get("/", response_class=HTMLResponse)
 def index(request: Request):
     return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.get("/settings", response_class=HTMLResponse)
+def settings(request: Request):
+    return templates.TemplateResponse("settings.html", {"request": request})

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -131,6 +131,7 @@ body {
     font-family: inherit;
     min-height: 44px;
     min-width: 44px;
+    text-decoration: none; /* the settings gear is an <a> styled as a button */
 }
 
 .btn:active { transform: scale(0.97); }
@@ -719,6 +720,45 @@ body {
     font-size: 0.85rem;
     color: var(--text-secondary);
     margin: -6px 0 12px;
+}
+
+/* ===== Settings page ===== */
+/* The settings form used to sit on the modal's card surface; on its own page
+   it supplies that surface itself, so the contents read the same as before. */
+.settings-page {
+    background: var(--bg-primary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 24px;
+}
+
+.back-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 44px;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+}
+
+.back-link:hover { color: var(--text-primary); }
+
+.page-title {
+    font-size: 1.4rem;
+    margin-bottom: 16px;
+}
+
+/* The header gear on /settings is a location marker, not a control. */
+.btn-icon[aria-current="page"] {
+    cursor: default;
+    opacity: 0.55;
+}
+
+/* The modal framed these sections; on a page they need their own separation.
+   Collapses against the preceding .form-group's 16px, so the gap is 28px, not
+   44px. The first title is skipped — the page heading already spaces it. */
+.settings-page .settings-section-title:not(:first-child) {
+    margin-top: 28px;
 }
 
 /* ===== Child Profiles ===== */

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -11,64 +11,6 @@ function generateUUID() {
     });
 }
 
-/* ===== API Client ===== */
-const api = {
-    async request(method, url, body = null) {
-        const opts = { method, cache: 'no-store', headers: { 'Content-Type': 'application/json' } };
-        if (body) opts.body = JSON.stringify(body);
-        const res = await fetch(url, opts);
-        if (!res.ok && res.status !== 204) {
-            const err = await res.json().catch(() => ({ detail: 'Request failed' }));
-            throw new Error(err.detail || 'Request failed');
-        }
-        if (res.status === 204) return null;
-        return res.json();
-    },
-    get: (url) => api.request('GET', url),
-    post: (url, body) => api.request('POST', url, body),
-    put: (url, body) => api.request('PUT', url, body),
-    del: (url) => api.request('DELETE', url),
-};
-
-/* ===== Toast ===== */
-let toastTimeout;
-function showToast(msg) {
-    const el = document.getElementById('toast');
-    el.textContent = msg;
-    el.classList.remove('hidden');
-    clearTimeout(toastTimeout);
-    toastTimeout = setTimeout(() => el.classList.add('hidden'), 2500);
-}
-
-/* ===== Breast Names ===== */
-const BREAST_LEFT_KEY = 'puffin-breast-left-name';
-const BREAST_RIGHT_KEY = 'puffin-breast-right-name';
-const DEFAULT_LEFT_NAME = 'Left';
-const DEFAULT_RIGHT_NAME = 'Right';
-
-/* ===== Bottle Defaults ===== */
-const BOTTLE_TYPE_KEY = 'puffin-bottle-type-default';
-const BOTTLE_UNIT_KEY = 'defaultBottleUnit';
-const DEFAULT_BOTTLE_TYPE = 'breastmilk';
-const DEFAULT_BOTTLE_UNIT = 'oz';
-
-function getDefaultBottleType() {
-    return localStorage.getItem(BOTTLE_TYPE_KEY) || DEFAULT_BOTTLE_TYPE;
-}
-
-function getDefaultBottleUnit() {
-    const unit = localStorage.getItem(BOTTLE_UNIT_KEY) || DEFAULT_BOTTLE_UNIT;
-    return unit === 'mL' ? 'mL' : 'oz';
-}
-
-function validateBottleAmountUnit(amount, unit) {
-    if (unit === 'mL' && !Number.isInteger(Number(amount))) {
-        showToast('mL amounts must be whole numbers');
-        return false;
-    }
-    return true;
-}
-
 function updateBottleUnitLabels() {
     const defaultUnit = getDefaultBottleUnit();
     const selects = [
@@ -99,13 +41,6 @@ function updateBottleTypeLabels() {
     }
 }
 
-function getBreastNames() {
-    return {
-        left: localStorage.getItem(BREAST_LEFT_KEY) || DEFAULT_LEFT_NAME,
-        right: localStorage.getItem(BREAST_RIGHT_KEY) || DEFAULT_RIGHT_NAME,
-    };
-}
-
 function updateBreastLabels() {
     const names = getBreastNames();
     // Feeding modal type buttons
@@ -118,146 +53,6 @@ function updateBreastLabels() {
     if (leftLabel) leftLabel.textContent = `🤱 ${names.left} breast (minutes)`;
     const rightLabel = document.querySelector('label[for="feeding-right-duration"]');
     if (rightLabel) rightLabel.textContent = `🤱 ${names.right} breast (minutes)`;
-}
-
-/* ===== Child Profiles ===== */
-// Profiles themselves live server-side with the logs they label; only the
-// *selection* is per-device, so two phones can view two children at once.
-const SELECTED_CHILD_KEY = 'puffin-selected-child';
-const UNASSIGNED_VIEW = 'unassigned';
-
-let childProfiles = [];
-let unassignedCount = 0;
-// null means "every log regardless of child" — what an install with no
-// profiles always shows, and exactly how Puffin behaved before profiles.
-let selectedChild = null;
-
-function hasProfiles() {
-    return childProfiles.length > 0;
-}
-
-function readStoredChild() {
-    const raw = localStorage.getItem(SELECTED_CHILD_KEY);
-    if (!raw) return null;
-    if (raw === UNASSIGNED_VIEW) return UNASSIGNED_VIEW;
-    const id = parseInt(raw, 10);
-    return Number.isNaN(id) ? null : id;
-}
-
-function storeSelectedChild(value) {
-    if (value === null) localStorage.removeItem(SELECTED_CHILD_KEY);
-    else localStorage.setItem(SELECTED_CHILD_KEY, String(value));
-}
-
-/** The current scope as a query fragment appended to dashboard/activity calls. */
-function childQuery() {
-    if (selectedChild === UNASSIGNED_VIEW) return '&unassigned=true';
-    if (typeof selectedChild === 'number') return `&child_id=${selectedChild}`;
-    return '';
-}
-
-/**
- * The child new logs are created against.
- *
- * Returns null in the unassigned view so a log created while looking at
- * unassigned logs stays unassigned, matching what is on screen.
- */
-function currentChildId() {
-    return typeof selectedChild === 'number' ? selectedChild : null;
-}
-
-function resolveSelectedChild() {
-    if (!hasProfiles()) return null;
-    const stored = readStoredChild();
-    // The unassigned view only survives while it still has something in it.
-    if (stored === UNASSIGNED_VIEW && unassignedCount > 0) return UNASSIGNED_VIEW;
-    if (typeof stored === 'number' && childProfiles.some(c => c.id === stored)) return stored;
-    return childProfiles[0].id; // default: the first profile created
-}
-
-async function loadChildren() {
-    try {
-        const [profiles, unassigned] = await Promise.all([
-            api.get('/api/children'),
-            api.get('/api/children/unassigned'),
-        ]);
-        childProfiles = profiles;
-        unassignedCount = unassigned.count;
-    } catch (err) {
-        // Do NOT fall back to an empty profile list: that is indistinguishable
-        // from a genuine zero-profile install, and persisting it would clear
-        // the stored selection and silently route every log created this
-        // session to "Unassigned". Keep the last known state instead and tell
-        // the user, so a flaky request stays a transient error.
-        console.error('Failed to load children:', err);
-        showToast('Could not load profiles — showing last known state');
-        return;
-    }
-    selectedChild = resolveSelectedChild();
-    storeSelectedChild(selectedChild);
-    renderChildSwitcher();
-    renderChildHeader();
-}
-
-function childOptionsHtml() {
-    return childProfiles
-        .map(c => `<option value="${c.id}">${escapeHtml(c.name)}</option>`)
-        .join('');
-}
-
-function renderChildSwitcher() {
-    const section = document.getElementById('child-switcher-section');
-    const select = document.getElementById('child-switcher');
-    section.classList.toggle('hidden', !hasProfiles());
-    if (!hasProfiles()) {
-        select.innerHTML = '';
-        return;
-    }
-    let html = childOptionsHtml();
-    // Offered only while logs actually sit outside every profile.
-    if (unassignedCount > 0) {
-        html += `<option value="${UNASSIGNED_VIEW}">Unassigned logs</option>`;
-    }
-    select.innerHTML = html;
-    select.value = String(selectedChild);
-}
-
-function selectedChildName() {
-    const match = childProfiles.find(c => c.id === selectedChild);
-    return match ? match.name : null;
-}
-
-function renderChildHeader() {
-    const title = document.getElementById('child-log-title');
-    const bar = document.getElementById('unassigned-bar');
-    const name = selectedChildName();
-
-    if (selectedChild === UNASSIGNED_VIEW) {
-        title.textContent = 'Unassigned Logs';
-    } else if (name) {
-        title.textContent = `${name}'s Care Logs`;
-    } else {
-        title.textContent = '';
-    }
-    title.classList.toggle('hidden', !title.textContent);
-
-    // The bulk re-assign is the permanent escape hatch that makes declining the
-    // one-time migration offer recoverable.
-    const showBar = selectedChild === UNASSIGNED_VIEW && hasProfiles();
-    bar.classList.toggle('hidden', !showBar);
-    if (showBar) {
-        const plural = unassignedCount === 1 ? '' : 's';
-        document.getElementById('unassigned-bar-count').textContent =
-            `${unassignedCount} log${plural} not linked to any child`;
-        document.getElementById('unassigned-assign-target').innerHTML = childOptionsHtml();
-    }
-}
-
-async function refreshChildUI() {
-    await loadChildren();
-    renderChildList();
-    renderExportChildOptions();
-    loadDashboard();
 }
 
 /**
@@ -273,235 +68,55 @@ function reloadAfterLogChange() {
     return loadDashboard();
 }
 
-/* --- Shared two-step confirmation --- */
+/* ===== Dashboard wiring for the shared layer ===== */
 
-function showChildConfirm({ title, body, note, primary, secondary, cancel,
-                            onPrimary, onSecondary, onCancel }) {
-    document.getElementById('child-confirm-title').textContent = title;
-    document.getElementById('child-confirm-body').textContent = body;
+// common.js keeps the child subsystem page-agnostic; these hooks add back the
+// parts only the dashboard owns.
+onChildDataChanged = () => {
+    renderExportChildOptions();
+    loadDashboard();
+};
 
-    const noteEl = document.getElementById('child-confirm-note');
-    noteEl.textContent = note || '';
-    noteEl.classList.toggle('hidden', !note);
-
-    const wire = (id, label, handler) => {
-        const btn = document.getElementById(id);
-        btn.classList.toggle('hidden', !label);
-        if (label) btn.textContent = label;
-        // Replacing the node drops listeners from a previous step, so the
-        // buttons never accumulate stale handlers across the flow.
-        const fresh = btn.cloneNode(true);
-        btn.parentNode.replaceChild(fresh, btn);
-        if (label && handler) fresh.addEventListener('click', handler);
-    };
-    wire('child-confirm-primary', primary, onPrimary);
-    wire('child-confirm-secondary', secondary, onSecondary);
-    wire('child-confirm-cancel', cancel, onCancel);
-
-    openModal('child-confirm-modal');
-}
-
-/* --- Creating a profile, and the one-time migration offer --- */
-
-async function addChild() {
-    const input = document.getElementById('child-new-name');
-    const name = input.value.trim();
-    if (!name) {
-        showToast('Please enter a first name');
-        input.focus();
-        return;
+onModalOpen = (id) => {
+    if (id === 'feeding-modal') {
+        loadLastBreastFeeding();
+        loadNoteSuggestions('/api/feedings', 'feeding-note-suggestions', 'feeding-notes');
+        updateBottleTypeLabels();
+        updateBottleUnitLabels();
+    } else if (id === 'diaper-modal') {
+        loadNoteSuggestions('/api/diapers', 'diaper-note-suggestions', 'diaper-notes');
+    } else if (id === 'health-modal') {
+        loadSavedMedNames();
+        loadMedDosageMap();
+        loadNoteSuggestions('/api/medications', 'med-note-suggestions', 'med-notes');
+        loadNoteSuggestions('/api/temperatures', 'temp-note-suggestions', 'temp-notes');
     }
+};
 
-    const isFirstProfile = !hasProfiles();
-    let created;
-    try {
-        created = await api.post('/api/children', { name });
-    } catch (err) {
-        showToast('Error: ' + err.message);
-        return;
+onModalClose = (id) => {
+    if (id === 'health-modal') {
+        resetMedAutocomplete();
     }
-    input.value = '';
-
-    // The bulk offer is made once: at first profile creation, on an install
-    // that already has logs.  Re-read the count so it reflects this moment.
-    // The profile already exists server-side, so a failure here must still
-    // fall through to showing it -- otherwise the new child never appears, no
-    // error is raised, and the user retries into a duplicate.  The migration
-    // offer isn't lost: it can be made later from "Unassigned logs".
-    if (isFirstProfile) {
-        try {
-            const { count } = await api.get('/api/children/unassigned');
-            if (count > 0) {
-                offerMigration(created, count);
-                return;
-            }
-        } catch (err) {
-            console.error('Failed to check for unassigned logs:', err);
-        }
+    // Reset feeding modal to timer mode
+    if (id === 'feeding-modal') {
+        document.getElementById('feeding-timer-mode').classList.remove('hidden');
+        document.getElementById('feeding-manual-mode').classList.add('hidden');
+        document.getElementById('feeding-bottle-timer').classList.add('hidden');
+        const timerRow = document.getElementById('timer-toggle-row');
+        if (timerRow) timerRow.classList.remove('hidden');
+        document.getElementById('feeding-save-btn').disabled = true;
+        document.getElementById('feeding-save-btn').textContent = 'Start';
     }
-    await refreshChildUI();
-    showToast(`${created.name} added`);
-}
+};
 
-function offerMigration(child, count) {
-    const plural = count === 1 ? '' : 's';
-    showChildConfirm({
-        title: 'Move existing logs?',
-        body: `You have ${count} care log${plural} that aren't linked to any child. `
-            + `Move them all to ${child.name}?`,
-        note: 'This bulk move is only offered once, when you create your first child. '
-            + 'You can always re-assign unassigned logs later from "Unassigned logs" '
-            + 'in the child menu.',
-        primary: 'Yes, move them',
-        secondary: 'No, leave them unassigned',
-        cancel: 'Cancel',
-        onPrimary: () => confirmMigration(child, count),
-        onSecondary: async () => {
-            closeModal('child-confirm-modal');
-            await refreshChildUI();
-            showToast(`${child.name} added`);
-        },
-        onCancel: () => cancelChildCreation(child),
-    });
-}
-
-function confirmMigration(child, count) {
-    const plural = count === 1 ? '' : 's';
-    showChildConfirm({
-        title: 'Confirm move',
-        body: `This will assign all ${count} existing log${plural} to ${child.name}. `
-            + `This can't be undone in bulk.`,
-        primary: `Confirm — move all logs to ${child.name}`,
-        secondary: 'Go back',
-        cancel: 'Cancel',
-        onPrimary: () => runBulkAssign(child),
-        onSecondary: () => offerMigration(child, count),
-        onCancel: () => cancelChildCreation(child),
-    });
-}
-
-/**
- * Cancel backs all the way out of profile creation.
- *
- * Deleting the just-created profile is what makes "go back and create a
- * different child first" work — the profile never half-exists.  It has no logs
- * of its own yet, so nothing is stranded.
- */
-async function cancelChildCreation(child) {
-    try {
-        await api.del(`/api/children/${child.id}`);
-    } catch (err) {
-        console.error('Failed to undo profile creation:', err);
-    }
-    closeModal('child-confirm-modal');
-    await refreshChildUI();
-    showToast('Profile creation cancelled');
-}
-
-async function runBulkAssign(child) {
-    try {
-        const result = await api.post(`/api/children/${child.id}/assign-unassigned`);
-        closeModal('child-confirm-modal');
-        await refreshChildUI();
-        const plural = result.assigned === 1 ? '' : 's';
-        showToast(`Moved ${result.assigned} log${plural} to ${child.name}`);
-    } catch (err) {
-        showToast('Error: ' + err.message);
-    }
-}
-
-/* --- Settings: the Children section --- */
-
-function renderChildList() {
-    const container = document.getElementById('child-list');
-    if (!hasProfiles()) {
-        container.innerHTML = '<p class="empty-state">No children yet.</p>';
-        return;
-    }
-    container.innerHTML = childProfiles.map(c => `
-        <div class="child-row" data-child-row="${c.id}">
-            <span class="child-row-name">${escapeHtml(c.name)}</span>
-            <button type="button" class="btn btn-sm btn-secondary" data-child-rename="${c.id}">Rename</button>
-            <button type="button" class="btn btn-sm btn-danger" data-child-delete="${c.id}">Delete</button>
-        </div>`).join('');
-}
-
-function startChildRename(childId) {
-    const child = childProfiles.find(c => c.id === childId);
-    const row = document.querySelector(`[data-child-row="${childId}"]`);
-    if (!child || !row) return;
-    row.innerHTML = `
-        <input type="text" class="child-rename-input" maxlength="30" value="${escapeAttr(child.name)}">
-        <button type="button" class="btn btn-sm btn-primary" data-child-rename-save="${childId}">Save</button>
-        <button type="button" class="btn btn-sm btn-secondary" data-child-rename-cancel="1">Cancel</button>`;
-    row.querySelector('.child-rename-input').focus();
-}
-
-async function saveChildRename(childId) {
-    const row = document.querySelector(`[data-child-row="${childId}"]`);
-    const name = row.querySelector('.child-rename-input').value.trim();
-    if (!name) {
-        showToast('Please enter a first name');
-        return;
-    }
-    try {
-        await api.put(`/api/children/${childId}`, { name });
-        await refreshChildUI();
-        showToast('Child renamed');
-    } catch (err) {
-        showToast('Error: ' + err.message);
-    }
-}
-
-function confirmChildDelete(childId) {
-    const child = childProfiles.find(c => c.id === childId);
-    if (!child) return;
-    showChildConfirm({
-        title: `Delete ${child.name}?`,
-        body: `${child.name}'s logs will be kept and moved to "Unassigned logs", `
-            + `where you can re-assign them. No log data is deleted.`,
-        primary: `Delete ${child.name}`,
-        cancel: 'Cancel',
-        onPrimary: async () => {
-            try {
-                await api.del(`/api/children/${childId}`);
-                closeModal('child-confirm-modal');
-                await refreshChildUI();
-                showToast(`${child.name} deleted — their logs are now unassigned`);
-            } catch (err) {
-                showToast('Error: ' + err.message);
-            }
-        },
-        onCancel: () => closeModal('child-confirm-modal'),
-    });
-}
-
-function initChildProfiles() {
+/** Wires the child controls the dashboard owns: the switcher and the bulk re-assign. */
+function initChildDashboard() {
     document.getElementById('child-switcher').addEventListener('change', (e) => {
         const raw = e.target.value;
         selectedChild = raw === UNASSIGNED_VIEW ? UNASSIGNED_VIEW : parseInt(raw, 10);
         storeSelectedChild(selectedChild);
         renderChildHeader();
         loadDashboard();
-    });
-
-    document.getElementById('child-add-btn').addEventListener('click', addChild);
-    document.getElementById('child-new-name').addEventListener('keydown', (e) => {
-        // The Children section lives inside the settings form; Enter here must
-        // add a child, not submit (and close) the whole settings modal.
-        if (e.key === 'Enter') {
-            e.preventDefault();
-            addChild();
-        }
-    });
-
-    document.getElementById('child-list').addEventListener('click', (e) => {
-        const btn = e.target.closest('button');
-        if (!btn) return;
-        if (btn.dataset.childRename) startChildRename(parseInt(btn.dataset.childRename, 10));
-        else if (btn.dataset.childRenameSave) saveChildRename(parseInt(btn.dataset.childRenameSave, 10));
-        else if (btn.dataset.childRenameCancel) renderChildList();
-        else if (btn.dataset.childDelete) confirmChildDelete(parseInt(btn.dataset.childDelete, 10));
     });
 
     document.getElementById('unassigned-assign-btn').addEventListener('click', () => {
@@ -531,79 +146,7 @@ function initChildProfiles() {
     });
 }
 
-/* ===== Dark Mode ===== */
-function initTheme() {
-    const saved = localStorage.getItem('puffin-theme');
-    if (saved) {
-        document.documentElement.setAttribute('data-theme', saved);
-    }
-    updateThemeIcon();
-}
 
-function toggleTheme() {
-    const current = document.documentElement.getAttribute('data-theme');
-    const isDark = current === 'dark' ||
-        (!current && window.matchMedia('(prefers-color-scheme: dark)').matches);
-    const next = isDark ? 'light' : 'dark';
-    document.documentElement.setAttribute('data-theme', next);
-    localStorage.setItem('puffin-theme', next);
-    updateThemeIcon();
-}
-
-function updateThemeIcon() {
-    const btn = document.getElementById('theme-toggle');
-    const theme = document.documentElement.getAttribute('data-theme');
-    const isDark = theme === 'dark' ||
-        (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
-    btn.textContent = isDark ? '☀️' : '🌙';
-}
-
-/* ===== Modals ===== */
-function openModal(id) {
-    document.getElementById(id).classList.remove('hidden');
-    if (id === 'feeding-modal') {
-        loadLastBreastFeeding();
-        loadNoteSuggestions('/api/feedings', 'feeding-note-suggestions', 'feeding-notes');
-        updateBottleTypeLabels();
-        updateBottleUnitLabels();
-    } else if (id === 'diaper-modal') {
-        loadNoteSuggestions('/api/diapers', 'diaper-note-suggestions', 'diaper-notes');
-    } else if (id === 'health-modal') {
-        loadSavedMedNames();
-        loadMedDosageMap();
-        loadNoteSuggestions('/api/medications', 'med-note-suggestions', 'med-notes');
-        loadNoteSuggestions('/api/temperatures', 'temp-note-suggestions', 'temp-notes');
-    }
-}
-
-function closeModal(id) {
-    document.getElementById(id).classList.add('hidden');
-    // Reset forms inside the modal
-    const forms = document.getElementById(id).querySelectorAll('form');
-    forms.forEach(f => {
-        f.reset();
-        f.querySelectorAll('button[type="submit"]').forEach(btn => { btn.disabled = false; });
-    });
-    // Clear selected buttons
-    document.getElementById(id).querySelectorAll('.btn-option.selected').forEach(b => b.classList.remove('selected'));
-    if (id === 'health-modal') {
-        resetMedAutocomplete();
-    }
-    // Reset feeding modal to timer mode
-    if (id === 'feeding-modal') {
-        document.getElementById('feeding-timer-mode').classList.remove('hidden');
-        document.getElementById('feeding-manual-mode').classList.add('hidden');
-        document.getElementById('feeding-bottle-timer').classList.add('hidden');
-        const timerRow = document.getElementById('timer-toggle-row');
-        if (timerRow) timerRow.classList.remove('hidden');
-        document.getElementById('feeding-save-btn').disabled = true;
-        document.getElementById('feeding-save-btn').textContent = 'Start';
-    }
-}
-
-function closeAllModals() {
-    document.querySelectorAll('.modal').forEach(m => m.classList.add('hidden'));
-}
 
 /* ===== Option Buttons ===== */
 function initOptionButtons() {
@@ -2104,50 +1647,6 @@ function getActivityLabel(a) {
     return a.label || a.summary;
 }
 
-function escapeHtml(str) {
-    if (!str) return '';
-    const div = document.createElement('div');
-    div.textContent = str;
-    return div.innerHTML;
-}
-
-function escapeAttr(str) {
-    if (!str) return '';
-    return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-}
-
-/* ===== Settings Modal ===== */
-function initSettings() {
-    document.getElementById('settings-btn').addEventListener('click', () => {
-        const names = getBreastNames();
-        document.getElementById('settings-left-name').value = names.left;
-        document.getElementById('settings-right-name').value = names.right;
-        document.getElementById('settings-bottle-type').value = getDefaultBottleType();
-        document.getElementById('settings-bottle-unit').value = getDefaultBottleUnit();
-        updateBottleUnitLabels();
-        renderChildList();
-        document.getElementById('child-new-name').value = '';
-        openModal('settings-modal');
-    });
-
-    document.getElementById('settings-form').addEventListener('submit', (e) => {
-        e.preventDefault();
-        const leftName = document.getElementById('settings-left-name').value.trim() || DEFAULT_LEFT_NAME;
-        const rightName = document.getElementById('settings-right-name').value.trim() || DEFAULT_RIGHT_NAME;
-        const bottleType = document.getElementById('settings-bottle-type').value;
-        const bottleUnit = document.getElementById('settings-bottle-unit').value;
-        localStorage.setItem(BREAST_LEFT_KEY, leftName);
-        localStorage.setItem(BREAST_RIGHT_KEY, rightName);
-        localStorage.setItem(BOTTLE_TYPE_KEY, bottleType);
-        localStorage.setItem(BOTTLE_UNIT_KEY, bottleUnit);
-        closeModal('settings-modal');
-        updateBreastLabels();
-        updateBottleTypeLabels();
-        updateBottleUnitLabels();
-        if (getTimerState()) showTimerUI();
-        showToast('Settings saved!');
-    });
-}
 
 /* ===== Export Modal ===== */
 const EXPORT_ALL_CHILDREN = 'all';
@@ -2213,16 +1712,14 @@ document.addEventListener('DOMContentLoaded', () => {
     initMedAutocomplete();
     initEditForm();
     initCalendar();
-    initSettings();
     initExport();
-    initChildProfiles();
+    initChildDashboard();
     updateBreastLabels();
     updateBottleTypeLabels();
     updateBottleUnitLabels();
     // Resolves the selected child before the first dashboard fetch, so the
     // counts are never briefly wrong for a multi-child install.
     loadChildren().then(() => {
-        renderChildList();
         loadDashboard();
     });
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -1,0 +1,529 @@
+/*
+ * Shared runtime for every Puffin page.
+ *
+ * Loaded before the page-specific script (app.js on the dashboard,
+ * settings.js on /settings), so anything both pages need lives here: the API
+ * client, toasts, theme, modal plumbing, the stored preferences, and the whole
+ * child-profile subsystem.
+ *
+ * These are plain <script> files, not modules, so top-level declarations here
+ * are visible to the page script that loads after them.
+ *
+ * Functions that touch page-specific DOM (the dashboard switcher, the settings
+ * child list) no-op when their element is absent rather than throwing, because
+ * the child subsystem genuinely runs on both pages and each page only owns
+ * part of the markup.
+ */
+
+/* ===== Escaping ===== */
+function escapeHtml(str) {
+    if (!str) return '';
+    const div = document.createElement('div');
+    div.textContent = str;
+    return div.innerHTML;
+}
+
+function escapeAttr(str) {
+    if (!str) return '';
+    return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+/* ===== API Client ===== */
+const api = {
+    async request(method, url, body = null) {
+        const opts = { method, cache: 'no-store', headers: { 'Content-Type': 'application/json' } };
+        if (body) opts.body = JSON.stringify(body);
+        const res = await fetch(url, opts);
+        if (!res.ok && res.status !== 204) {
+            const err = await res.json().catch(() => ({ detail: 'Request failed' }));
+            throw new Error(err.detail || 'Request failed');
+        }
+        if (res.status === 204) return null;
+        return res.json();
+    },
+    get: (url) => api.request('GET', url),
+    post: (url, body) => api.request('POST', url, body),
+    put: (url, body) => api.request('PUT', url, body),
+    del: (url) => api.request('DELETE', url),
+};
+
+/* ===== Toast ===== */
+let toastTimeout;
+function showToast(msg) {
+    const el = document.getElementById('toast');
+    if (!el) return;
+    el.textContent = msg;
+    el.classList.remove('hidden');
+    clearTimeout(toastTimeout);
+    toastTimeout = setTimeout(() => el.classList.add('hidden'), 2500);
+}
+
+/* ===== Breast Names ===== */
+const BREAST_LEFT_KEY = 'puffin-breast-left-name';
+const BREAST_RIGHT_KEY = 'puffin-breast-right-name';
+const DEFAULT_LEFT_NAME = 'Left';
+const DEFAULT_RIGHT_NAME = 'Right';
+
+/* ===== Bottle Defaults ===== */
+const BOTTLE_TYPE_KEY = 'puffin-bottle-type-default';
+const BOTTLE_UNIT_KEY = 'defaultBottleUnit';
+const DEFAULT_BOTTLE_TYPE = 'breastmilk';
+const DEFAULT_BOTTLE_UNIT = 'oz';
+
+function getDefaultBottleType() {
+    return localStorage.getItem(BOTTLE_TYPE_KEY) || DEFAULT_BOTTLE_TYPE;
+}
+
+function getDefaultBottleUnit() {
+    const unit = localStorage.getItem(BOTTLE_UNIT_KEY) || DEFAULT_BOTTLE_UNIT;
+    return unit === 'mL' ? 'mL' : 'oz';
+}
+
+function validateBottleAmountUnit(amount, unit) {
+    if (unit === 'mL' && !Number.isInteger(Number(amount))) {
+        showToast('mL amounts must be whole numbers');
+        return false;
+    }
+    return true;
+}
+
+function getBreastNames() {
+    return {
+        left: localStorage.getItem(BREAST_LEFT_KEY) || DEFAULT_LEFT_NAME,
+        right: localStorage.getItem(BREAST_RIGHT_KEY) || DEFAULT_RIGHT_NAME,
+    };
+}
+
+/* ===== Child Profiles ===== */
+// Profiles themselves live server-side with the logs they label; only the
+// *selection* is per-device, so two phones can view two children at once.
+const SELECTED_CHILD_KEY = 'puffin-selected-child';
+const UNASSIGNED_VIEW = 'unassigned';
+
+let childProfiles = [];
+let unassignedCount = 0;
+// null means "every log regardless of child" — what an install with no
+// profiles always shows, and exactly how Puffin behaved before profiles.
+let selectedChild = null;
+
+/**
+ * What to re-render after child data changes, beyond the pieces both pages
+ * share. The dashboard refreshes its export options and timeline; the settings
+ * page has neither and leaves this as the no-op.
+ */
+let onChildDataChanged = () => {};
+
+function hasProfiles() {
+    return childProfiles.length > 0;
+}
+
+function readStoredChild() {
+    const raw = localStorage.getItem(SELECTED_CHILD_KEY);
+    if (!raw) return null;
+    if (raw === UNASSIGNED_VIEW) return UNASSIGNED_VIEW;
+    const id = parseInt(raw, 10);
+    return Number.isNaN(id) ? null : id;
+}
+
+function storeSelectedChild(value) {
+    if (value === null) localStorage.removeItem(SELECTED_CHILD_KEY);
+    else localStorage.setItem(SELECTED_CHILD_KEY, String(value));
+}
+
+/** The current scope as a query fragment appended to dashboard/activity calls. */
+function childQuery() {
+    if (selectedChild === UNASSIGNED_VIEW) return '&unassigned=true';
+    if (typeof selectedChild === 'number') return `&child_id=${selectedChild}`;
+    return '';
+}
+
+/**
+ * The child new logs are created against.
+ *
+ * Returns null in the unassigned view so a log created while looking at
+ * unassigned logs stays unassigned, matching what is on screen.
+ */
+function currentChildId() {
+    return typeof selectedChild === 'number' ? selectedChild : null;
+}
+
+function resolveSelectedChild() {
+    if (!hasProfiles()) return null;
+    const stored = readStoredChild();
+    // The unassigned view only survives while it still has something in it.
+    if (stored === UNASSIGNED_VIEW && unassignedCount > 0) return UNASSIGNED_VIEW;
+    if (typeof stored === 'number' && childProfiles.some(c => c.id === stored)) return stored;
+    return childProfiles[0].id; // default: the first profile created
+}
+
+async function loadChildren() {
+    try {
+        const [profiles, unassigned] = await Promise.all([
+            api.get('/api/children'),
+            api.get('/api/children/unassigned'),
+        ]);
+        childProfiles = profiles;
+        unassignedCount = unassigned.count;
+    } catch (err) {
+        // Do NOT fall back to an empty profile list: that is indistinguishable
+        // from a genuine zero-profile install, and persisting it would clear
+        // the stored selection and silently route every log created this
+        // session to "Unassigned". Keep the last known state instead and tell
+        // the user, so a flaky request stays a transient error.
+        console.error('Failed to load children:', err);
+        showToast('Could not load profiles — showing last known state');
+        return;
+    }
+    selectedChild = resolveSelectedChild();
+    storeSelectedChild(selectedChild);
+    renderChildSwitcher();
+    renderChildHeader();
+}
+
+function childOptionsHtml() {
+    return childProfiles
+        .map(c => `<option value="${c.id}">${escapeHtml(c.name)}</option>`)
+        .join('');
+}
+
+function selectedChildName() {
+    const match = childProfiles.find(c => c.id === selectedChild);
+    return match ? match.name : null;
+}
+
+/* --- Dashboard-owned child chrome (absent on /settings) --- */
+
+function renderChildSwitcher() {
+    const section = document.getElementById('child-switcher-section');
+    const select = document.getElementById('child-switcher');
+    if (!section || !select) return;
+    section.classList.toggle('hidden', !hasProfiles());
+    if (!hasProfiles()) {
+        select.innerHTML = '';
+        return;
+    }
+    let html = childOptionsHtml();
+    // Offered only while logs actually sit outside every profile.
+    if (unassignedCount > 0) {
+        html += `<option value="${UNASSIGNED_VIEW}">Unassigned logs</option>`;
+    }
+    select.innerHTML = html;
+    select.value = String(selectedChild);
+}
+
+function renderChildHeader() {
+    const title = document.getElementById('child-log-title');
+    const bar = document.getElementById('unassigned-bar');
+    if (!title || !bar) return;
+    const name = selectedChildName();
+
+    if (selectedChild === UNASSIGNED_VIEW) {
+        title.textContent = 'Unassigned Logs';
+    } else if (name) {
+        title.textContent = `${name}'s Care Logs`;
+    } else {
+        title.textContent = '';
+    }
+    title.classList.toggle('hidden', !title.textContent);
+
+    // The bulk re-assign is the permanent escape hatch that makes declining the
+    // one-time migration offer recoverable.
+    const showBar = selectedChild === UNASSIGNED_VIEW && hasProfiles();
+    bar.classList.toggle('hidden', !showBar);
+    if (showBar) {
+        const plural = unassignedCount === 1 ? '' : 's';
+        document.getElementById('unassigned-bar-count').textContent =
+            `${unassignedCount} log${plural} not linked to any child`;
+        document.getElementById('unassigned-assign-target').innerHTML = childOptionsHtml();
+    }
+}
+
+async function refreshChildUI() {
+    await loadChildren();
+    renderChildList();
+    onChildDataChanged();
+}
+
+/* --- Shared two-step confirmation --- */
+
+function showChildConfirm({ title, body, note, primary, secondary, cancel,
+                            onPrimary, onSecondary, onCancel }) {
+    document.getElementById('child-confirm-title').textContent = title;
+    document.getElementById('child-confirm-body').textContent = body;
+
+    const noteEl = document.getElementById('child-confirm-note');
+    noteEl.textContent = note || '';
+    noteEl.classList.toggle('hidden', !note);
+
+    const wire = (id, label, handler) => {
+        const btn = document.getElementById(id);
+        btn.classList.toggle('hidden', !label);
+        if (label) btn.textContent = label;
+        // Replacing the node drops listeners from a previous step, so the
+        // buttons never accumulate stale handlers across the flow.
+        const fresh = btn.cloneNode(true);
+        btn.parentNode.replaceChild(fresh, btn);
+        if (label && handler) fresh.addEventListener('click', handler);
+    };
+    wire('child-confirm-primary', primary, onPrimary);
+    wire('child-confirm-secondary', secondary, onSecondary);
+    wire('child-confirm-cancel', cancel, onCancel);
+
+    openModal('child-confirm-modal');
+}
+
+/* --- Creating a profile, and the one-time migration offer --- */
+
+async function addChild() {
+    const input = document.getElementById('child-new-name');
+    const name = input.value.trim();
+    if (!name) {
+        showToast('Please enter a first name');
+        input.focus();
+        return;
+    }
+
+    const isFirstProfile = !hasProfiles();
+    let created;
+    try {
+        created = await api.post('/api/children', { name });
+    } catch (err) {
+        showToast('Error: ' + err.message);
+        return;
+    }
+    input.value = '';
+
+    // The bulk offer is made once: at first profile creation, on an install
+    // that already has logs.  Re-read the count so it reflects this moment.
+    // The profile already exists server-side, so a failure here must still
+    // fall through to showing it -- otherwise the new child never appears, no
+    // error is raised, and the user retries into a duplicate.  The migration
+    // offer isn't lost: it can be made later from "Unassigned logs".
+    if (isFirstProfile) {
+        try {
+            const { count } = await api.get('/api/children/unassigned');
+            if (count > 0) {
+                offerMigration(created, count);
+                return;
+            }
+        } catch (err) {
+            console.error('Failed to check for unassigned logs:', err);
+        }
+    }
+    await refreshChildUI();
+    showToast(`${created.name} added`);
+}
+
+function offerMigration(child, count) {
+    const plural = count === 1 ? '' : 's';
+    showChildConfirm({
+        title: 'Move existing logs?',
+        body: `You have ${count} care log${plural} that aren't linked to any child. `
+            + `Move them all to ${child.name}?`,
+        note: 'This bulk move is only offered once, when you create your first child. '
+            + 'You can always re-assign unassigned logs later from "Unassigned logs" '
+            + 'in the child menu.',
+        primary: 'Yes, move them',
+        secondary: 'No, leave them unassigned',
+        cancel: 'Cancel',
+        onPrimary: () => confirmMigration(child, count),
+        onSecondary: async () => {
+            closeModal('child-confirm-modal');
+            await refreshChildUI();
+            showToast(`${child.name} added`);
+        },
+        onCancel: () => cancelChildCreation(child),
+    });
+}
+
+function confirmMigration(child, count) {
+    const plural = count === 1 ? '' : 's';
+    showChildConfirm({
+        title: 'Confirm move',
+        body: `This will assign all ${count} existing log${plural} to ${child.name}. `
+            + `This can't be undone in bulk.`,
+        primary: `Confirm — move all logs to ${child.name}`,
+        secondary: 'Go back',
+        cancel: 'Cancel',
+        onPrimary: () => runBulkAssign(child),
+        onSecondary: () => offerMigration(child, count),
+        onCancel: () => cancelChildCreation(child),
+    });
+}
+
+/**
+ * Cancel backs all the way out of profile creation.
+ *
+ * Deleting the just-created profile is what makes "go back and create a
+ * different child first" work — the profile never half-exists.  It has no logs
+ * of its own yet, so nothing is stranded.
+ */
+async function cancelChildCreation(child) {
+    try {
+        await api.del(`/api/children/${child.id}`);
+    } catch (err) {
+        console.error('Failed to undo profile creation:', err);
+    }
+    closeModal('child-confirm-modal');
+    await refreshChildUI();
+    showToast('Profile creation cancelled');
+}
+
+async function runBulkAssign(child) {
+    try {
+        const result = await api.post(`/api/children/${child.id}/assign-unassigned`);
+        closeModal('child-confirm-modal');
+        await refreshChildUI();
+        const plural = result.assigned === 1 ? '' : 's';
+        showToast(`Moved ${result.assigned} log${plural} to ${child.name}`);
+    } catch (err) {
+        showToast('Error: ' + err.message);
+    }
+}
+
+/* --- Settings: the Children section (absent on the dashboard) --- */
+
+function renderChildList() {
+    const container = document.getElementById('child-list');
+    if (!container) return;
+    if (!hasProfiles()) {
+        container.innerHTML = '<p class="empty-state">No children yet.</p>';
+        return;
+    }
+    container.innerHTML = childProfiles.map(c => `
+        <div class="child-row" data-child-row="${c.id}">
+            <span class="child-row-name">${escapeHtml(c.name)}</span>
+            <button type="button" class="btn btn-sm btn-secondary" data-child-rename="${c.id}">Rename</button>
+            <button type="button" class="btn btn-sm btn-danger" data-child-delete="${c.id}">Delete</button>
+        </div>`).join('');
+}
+
+function startChildRename(childId) {
+    const child = childProfiles.find(c => c.id === childId);
+    const row = document.querySelector(`[data-child-row="${childId}"]`);
+    if (!child || !row) return;
+    row.innerHTML = `
+        <input type="text" class="child-rename-input" maxlength="30" value="${escapeAttr(child.name)}">
+        <button type="button" class="btn btn-sm btn-primary" data-child-rename-save="${childId}">Save</button>
+        <button type="button" class="btn btn-sm btn-secondary" data-child-rename-cancel="1">Cancel</button>`;
+    row.querySelector('.child-rename-input').focus();
+}
+
+async function saveChildRename(childId) {
+    const row = document.querySelector(`[data-child-row="${childId}"]`);
+    const name = row.querySelector('.child-rename-input').value.trim();
+    if (!name) {
+        showToast('Please enter a first name');
+        return;
+    }
+    try {
+        await api.put(`/api/children/${childId}`, { name });
+        await refreshChildUI();
+        showToast('Child renamed');
+    } catch (err) {
+        showToast('Error: ' + err.message);
+    }
+}
+
+function confirmChildDelete(childId) {
+    const child = childProfiles.find(c => c.id === childId);
+    if (!child) return;
+    showChildConfirm({
+        title: `Delete ${child.name}?`,
+        body: `${child.name}'s logs will be kept and moved to "Unassigned logs", `
+            + `where you can re-assign them. No log data is deleted.`,
+        primary: `Delete ${child.name}`,
+        cancel: 'Cancel',
+        onPrimary: async () => {
+            try {
+                await api.del(`/api/children/${childId}`);
+                closeModal('child-confirm-modal');
+                await refreshChildUI();
+                showToast(`${child.name} deleted — their logs are now unassigned`);
+            } catch (err) {
+                showToast('Error: ' + err.message);
+            }
+        },
+        onCancel: () => closeModal('child-confirm-modal'),
+    });
+}
+
+/** Wires the Children section. Only the settings page has this markup. */
+function initChildSettings() {
+    document.getElementById('child-add-btn').addEventListener('click', addChild);
+    document.getElementById('child-new-name').addEventListener('keydown', (e) => {
+        // The Children section lives inside the settings form; Enter here must
+        // add a child, not submit (and save) the whole settings form.
+        if (e.key === 'Enter') {
+            e.preventDefault();
+            addChild();
+        }
+    });
+
+    document.getElementById('child-list').addEventListener('click', (e) => {
+        const btn = e.target.closest('button');
+        if (!btn) return;
+        if (btn.dataset.childRename) startChildRename(parseInt(btn.dataset.childRename, 10));
+        else if (btn.dataset.childRenameSave) saveChildRename(parseInt(btn.dataset.childRenameSave, 10));
+        else if (btn.dataset.childRenameCancel) renderChildList();
+        else if (btn.dataset.childDelete) confirmChildDelete(parseInt(btn.dataset.childDelete, 10));
+    });
+}
+
+/* ===== Dark Mode ===== */
+function initTheme() {
+    const saved = localStorage.getItem('puffin-theme');
+    if (saved) {
+        document.documentElement.setAttribute('data-theme', saved);
+    }
+    updateThemeIcon();
+}
+
+function toggleTheme() {
+    const current = document.documentElement.getAttribute('data-theme');
+    const isDark = current === 'dark' ||
+        (!current && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    const next = isDark ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('puffin-theme', next);
+    updateThemeIcon();
+}
+
+function updateThemeIcon() {
+    const btn = document.getElementById('theme-toggle');
+    if (!btn) return;
+    const theme = document.documentElement.getAttribute('data-theme');
+    const isDark = theme === 'dark' ||
+        (!theme && window.matchMedia('(prefers-color-scheme: dark)').matches);
+    btn.textContent = isDark ? '☀️' : '🌙';
+}
+
+/* ===== Modals ===== */
+// The generic open/close both pages need. The dashboard's modals also prime
+// and reset their own contents; it registers that through these hooks rather
+// than teaching the shared layer about feeding, diaper, and health markup that
+// only exists on one page.
+let onModalOpen = () => {};
+let onModalClose = () => {};
+
+function openModal(id) {
+    document.getElementById(id).classList.remove('hidden');
+    onModalOpen(id);
+}
+
+function closeModal(id) {
+    const modal = document.getElementById(id);
+    modal.classList.add('hidden');
+    // Reset forms inside the modal
+    modal.querySelectorAll('form').forEach(f => {
+        f.reset();
+        f.querySelectorAll('button[type="submit"]').forEach(btn => { btn.disabled = false; });
+    });
+    // Clear selected buttons
+    modal.querySelectorAll('.btn-option.selected').forEach(b => b.classList.remove('selected'));
+    onModalClose(id);
+}
+
+function closeAllModals() {
+    document.querySelectorAll('.modal').forEach(m => m.classList.add('hidden'));
+}

--- a/static/js/settings.js
+++ b/static/js/settings.js
@@ -1,0 +1,86 @@
+/*
+ * The /settings page.
+ *
+ * Loads after common.js, which supplies the API client, toasts, theme, modal
+ * plumbing, and the whole child-profile subsystem (including the Children
+ * section's add/rename/delete).
+ *
+ * Two save models coexist here, deliberately:
+ *   - Children are server-backed and apply immediately.
+ *   - Breast names and feeding defaults are per-device preferences held in
+ *     localStorage, and only persist when Save is pressed.
+ * Save therefore tracks only the second group.
+ */
+
+/* ===== Preferences form ===== */
+
+// The deferred fields. Editing any of these arms Save; the Children controls
+// deliberately do not, since they have already persisted on their own.
+const PREF_FIELD_IDS = [
+    'settings-left-name',
+    'settings-right-name',
+    'settings-bottle-type',
+    'settings-bottle-unit',
+];
+
+function setSaveEnabled(enabled) {
+    document.getElementById('settings-save-btn').disabled = !enabled;
+}
+
+/** Fills the preference inputs from localStorage. */
+function hydrateSettingsForm() {
+    const names = getBreastNames();
+    document.getElementById('settings-left-name').value = names.left;
+    document.getElementById('settings-right-name').value = names.right;
+    document.getElementById('settings-bottle-type').value = getDefaultBottleType();
+    document.getElementById('settings-bottle-unit').value = getDefaultBottleUnit();
+}
+
+function savePreferences() {
+    const leftName = document.getElementById('settings-left-name').value.trim() || DEFAULT_LEFT_NAME;
+    const rightName = document.getElementById('settings-right-name').value.trim() || DEFAULT_RIGHT_NAME;
+    const bottleType = document.getElementById('settings-bottle-type').value;
+    const bottleUnit = document.getElementById('settings-bottle-unit').value;
+    localStorage.setItem(BREAST_LEFT_KEY, leftName);
+    localStorage.setItem(BREAST_RIGHT_KEY, rightName);
+    localStorage.setItem(BOTTLE_TYPE_KEY, bottleType);
+    localStorage.setItem(BOTTLE_UNIT_KEY, bottleUnit);
+
+    // An empty name falls back to the default, so reflect what was actually
+    // stored rather than leaving the blank box the user typed.
+    hydrateSettingsForm();
+    // Nothing left unsaved. The dashboard picks these up on its next load.
+    setSaveEnabled(false);
+    showToast('Settings saved!');
+}
+
+function initSettingsForm() {
+    hydrateSettingsForm();
+    setSaveEnabled(false);
+
+    for (const id of PREF_FIELD_IDS) {
+        const el = document.getElementById(id);
+        // `input` covers typing in the text fields; `change` covers the selects.
+        el.addEventListener('input', () => setSaveEnabled(true));
+        el.addEventListener('change', () => setSaveEnabled(true));
+    }
+
+    document.getElementById('settings-form').addEventListener('submit', (e) => {
+        e.preventDefault();
+        savePreferences();
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initTheme();
+    initSettingsForm();
+    initChildSettings();
+
+    loadChildren().then(renderChildList);
+
+    document.getElementById('theme-toggle').addEventListener('click', toggleTheme);
+
+    // The only modal on this page is the two-step child confirmation, whose
+    // backdrop is static by design; its buttons wire themselves in
+    // showChildConfirm. Nothing else here opens a modal.
+});

--- a/templates/_child_confirm_modal.html
+++ b/templates/_child_confirm_modal.html
@@ -1,0 +1,22 @@
+<!--
+  Two-step confirmation shared by the first-profile migration offer and the
+  bulk re-assign from the unassigned view.  Its backdrop is marked static so
+  a stray click cannot dismiss a half-finished migration — every exit runs
+  through the buttons, which clean up after themselves.
+
+  Included by both pages: the migration offer and child deletion are driven
+  from /settings, while the bulk re-assign is driven from the dashboard.
+-->
+<div id="child-confirm-modal" class="modal hidden">
+    <div class="modal-backdrop modal-backdrop-static"></div>
+    <div class="modal-content">
+        <h2 id="child-confirm-title"></h2>
+        <p id="child-confirm-body"></p>
+        <p id="child-confirm-note" class="settings-hint hidden"></p>
+        <div class="form-actions">
+            <button type="button" id="child-confirm-primary" class="btn btn-primary btn-lg"></button>
+            <button type="button" id="child-confirm-secondary" class="btn btn-secondary"></button>
+            <button type="button" id="child-confirm-cancel" class="btn btn-secondary"></button>
+        </div>
+    </div>
+</div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
     <header class="app-header">
         <h1 class="logo">🐧 Puffin</h1>
         <div class="header-actions">
-            <button id="settings-btn" class="btn btn-icon" aria-label="Open settings">⚙️</button>
+            <a href="/settings" id="settings-btn" class="btn btn-icon" aria-label="Settings">⚙️</a>
             <button id="theme-toggle" class="btn btn-icon" aria-label="Toggle dark mode">🌙</button>
         </div>
     </header>
@@ -324,52 +324,6 @@
         </div>
     </div>
 
-    <!-- Settings Modal -->
-    <div id="settings-modal" class="modal hidden">
-        <div class="modal-backdrop"></div>
-        <div class="modal-content">
-            <h2>Settings</h2>
-            <form id="settings-form">
-                <h3 class="settings-section-title">Children</h3>
-                <p class="settings-hint">Optional. Add a child to track each one's logs separately.</p>
-                <div id="child-list" class="child-list"></div>
-                <div class="form-group child-add-row">
-                    <label class="sr-only" for="child-new-name">First name</label>
-                    <input type="text" id="child-new-name" maxlength="30" placeholder="First name">
-                    <button type="button" id="child-add-btn" class="btn btn-sm btn-secondary">+ Add a child</button>
-                </div>
-                <h3 class="settings-section-title">Breast Names</h3>
-                <div class="form-group">
-                    <label for="settings-left-name">Left breast name</label>
-                    <input type="text" id="settings-left-name" maxlength="30" placeholder="Left">
-                </div>
-                <div class="form-group">
-                    <label for="settings-right-name">Right breast name</label>
-                    <input type="text" id="settings-right-name" maxlength="30" placeholder="Right">
-                </div>
-                <h3 class="settings-section-title">Feeding Defaults</h3>
-                <div class="form-group">
-                    <label for="settings-bottle-type">Default bottle type</label>
-                    <select id="settings-bottle-type">
-                        <option value="breastmilk">Breastmilk</option>
-                        <option value="formula">Formula</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <label for="settings-bottle-unit">Default bottle unit</label>
-                    <select id="settings-bottle-unit">
-                        <option value="oz">oz</option>
-                        <option value="mL">mL</option>
-                    </select>
-                </div>
-                <div class="form-actions">
-                    <button type="submit" class="btn btn-primary btn-lg">Save</button>
-                    <button type="button" class="btn btn-secondary modal-close">Cancel</button>
-                </div>
-            </form>
-        </div>
-    </div>
-
     <!-- Export Modal -->
     <div id="export-modal" class="modal hidden">
         <div class="modal-backdrop"></div>
@@ -405,29 +359,12 @@
         </div>
     </div>
 
-    <!--
-      Two-step confirmation shared by the first-profile migration offer and the
-      bulk re-assign from the unassigned view.  Its backdrop is marked static so
-      a stray click cannot dismiss a half-finished migration — every exit runs
-      through the buttons, which clean up after themselves.
-    -->
-    <div id="child-confirm-modal" class="modal hidden">
-        <div class="modal-backdrop modal-backdrop-static"></div>
-        <div class="modal-content">
-            <h2 id="child-confirm-title"></h2>
-            <p id="child-confirm-body"></p>
-            <p id="child-confirm-note" class="settings-hint hidden"></p>
-            <div class="form-actions">
-                <button type="button" id="child-confirm-primary" class="btn btn-primary btn-lg"></button>
-                <button type="button" id="child-confirm-secondary" class="btn btn-secondary"></button>
-                <button type="button" id="child-confirm-cancel" class="btn btn-secondary"></button>
-            </div>
-        </div>
-    </div>
+    {% include "_child_confirm_modal.html" %}
 
     <!-- Toast notification -->
     <div id="toast" class="toast hidden"></div>
 
+    <script src="/static/js/common.js"></script>
     <script src="/static/js/app.js"></script>
 </body>
 </html>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Settings - Puffin</title>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🐦</text></svg>">
+    <link rel="stylesheet" href="/static/css/styles.css">
+</head>
+<body>
+    <header class="app-header">
+        <h1 class="logo">🐧 Puffin</h1>
+        <div class="header-actions">
+            <!--
+              The gear marks the current page rather than linking to it. A
+              self-link would reload /settings and silently discard unsaved
+              preference edits, since Save is the only thing that persists them.
+            -->
+            <span id="settings-btn" class="btn btn-icon" aria-current="page"
+                  aria-label="Settings (current page)" role="img">⚙️</span>
+            <button id="theme-toggle" class="btn btn-icon" aria-label="Toggle dark mode">🌙</button>
+        </div>
+    </header>
+
+    <main class="container">
+        <a href="/" class="back-link">← Back to Dashboard</a>
+        <h2 class="page-title">Settings</h2>
+
+        <form id="settings-form" class="settings-page">
+            <h3 class="settings-section-title">Children</h3>
+            <p class="settings-hint">Optional. Add a child to track each one's logs separately.</p>
+            <div id="child-list" class="child-list"></div>
+            <div class="form-group child-add-row">
+                <label class="sr-only" for="child-new-name">First name</label>
+                <input type="text" id="child-new-name" maxlength="30" placeholder="First name">
+                <button type="button" id="child-add-btn" class="btn btn-sm btn-secondary">+ Add a child</button>
+            </div>
+            <h3 class="settings-section-title">Breast Names</h3>
+            <div class="form-group">
+                <label for="settings-left-name">Left breast name</label>
+                <input type="text" id="settings-left-name" maxlength="30" placeholder="Left">
+            </div>
+            <div class="form-group">
+                <label for="settings-right-name">Right breast name</label>
+                <input type="text" id="settings-right-name" maxlength="30" placeholder="Right">
+            </div>
+            <h3 class="settings-section-title">Feeding Defaults</h3>
+            <div class="form-group">
+                <label for="settings-bottle-type">Default bottle type</label>
+                <select id="settings-bottle-type">
+                    <option value="breastmilk">Breastmilk</option>
+                    <option value="formula">Formula</option>
+                </select>
+            </div>
+            <div class="form-group">
+                <label for="settings-bottle-unit">Default bottle unit</label>
+                <select id="settings-bottle-unit">
+                    <option value="oz">oz</option>
+                    <option value="mL">mL</option>
+                </select>
+            </div>
+            <div class="form-actions">
+                <button type="submit" id="settings-save-btn" class="btn btn-primary btn-lg">Save</button>
+            </div>
+        </form>
+    </main>
+
+    {% include "_child_confirm_modal.html" %}
+
+    <!-- Toast notification -->
+    <div id="toast" class="toast hidden"></div>
+
+    <script src="/static/js/common.js"></script>
+    <script src="/static/js/settings.js"></script>
+</body>
+</html>

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -1,6 +1,7 @@
 # Frontend tests
 
-These cover `static/js/app.js` using Node's built-in test runner
+These cover the dashboard's scripts — `static/js/common.js` and
+`static/js/app.js` — using Node's built-in test runner
 (`node:test` + `node:assert`). There are **no npm dependencies** — the only
 requirement is the `node` binary, which devenv provides.
 
@@ -8,17 +9,25 @@ Run them with `test-js` (or `test` for both suites).
 
 ## How it works
 
-`app.js` ships as a plain browser `<script>`: top-level `function`
-declarations and a single `DOMContentLoaded` bootstrap at the bottom, with no
-module exports. `harness.mjs` evaluates the file's source in an isolated scope
-and appends an epilogue — running in that same scope — that hands back the
-functions plus getter/setters for the mutable `let` state (`selectedChild`,
-`childProfiles`, `unassignedCount`).
+Both files ship as plain browser `<script>`s: top-level `function`
+declarations and a single `DOMContentLoaded` bootstrap at the bottom of
+`app.js`, with no module exports. `harness.mjs` concatenates them in the same
+order the dashboard's `<script>` tags load them (`common.js`, then `app.js`),
+evaluates the result in an isolated scope, and appends an epilogue — running in
+that same scope — that hands back the functions plus getter/setters for the
+mutable `let` state (`selectedChild`, `childProfiles`, `unassignedCount`).
 
-The shipped file is used **byte-for-byte and never modified**, so a test that
+Concatenating reproduces the single shared scope the browser gives these
+classic scripts, so a function in `app.js` can still see a declaration in
+`common.js`. Adding a third file (e.g. `settings.js`) means adding it to
+`SOURCE_FILES` — but note `settings.js` and `app.js` each declare their own
+`DOMContentLoaded` bootstrap and are never loaded together in a browser, so
+they should not be concatenated into the same scope.
+
+The shipped files are used **byte-for-byte and never modified**, so a test that
 passes reflects the code that actually runs in the browser. If a covered
-function is renamed, the epilogue throws `ReferenceError` at load — a
-deliberate tripwire.
+function is renamed or moved out of both files, the epilogue throws
+`ReferenceError` at load — a deliberate tripwire.
 
 The harness injects a fixed `Date` (deterministic relative-time formatting), a
 Map-backed `localStorage`, a `console` that records `error` calls, and no-op

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -1,11 +1,11 @@
-// Test harness for static/js/app.js.
+// Test harness for the dashboard's scripts: static/js/common.js + app.js.
 //
-// app.js ships as a plain browser <script>: global `function` declarations and
-// a single DOMContentLoaded bootstrap at the very bottom, no exports. Rather
-// than refactor 2200 lines that have no tests yet, this harness evaluates the
-// source in a controlled scope and appends an epilogue -- running in that same
+// Both ship as plain browser <script>s: global `function` declarations and a
+// single DOMContentLoaded bootstrap at the very bottom of app.js, no exports.
+// Rather than refactor code that has no tests yet, this harness evaluates the
+// sources in a controlled scope and appends an epilogue -- running in that same
 // scope -- that hands back the functions and getter/setters for the mutable
-// `let` state. The shipped file is used byte-for-byte and never modified.
+// `let` state. The shipped files are used byte-for-byte and never modified.
 //
 // DOM-free functions load with no options. DOM-driven ones (the timer state
 // machine, the calendar rollover, loadChildren) need loadApp({ dom: true }),
@@ -18,7 +18,14 @@ import { createDocument } from './fake-dom.mjs';
 import { dirname, join } from 'node:path';
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-const APP_PATH = join(HERE, '..', '..', 'static', 'js', 'app.js');
+const STATIC_JS = join(HERE, '..', '..', 'static', 'js');
+
+// Concatenated in the same order the dashboard's <script> tags load them:
+// common.js declares the shared layer (API client, toasts, theme, modals, the
+// child-profile subsystem), app.js the dashboard on top of it. Evaluating them
+// together reproduces the single shared scope the browser gives these classic
+// scripts, so a function in one can still see a declaration in the other.
+const SOURCE_FILES = ['common.js', 'app.js'];
 
 // The surface we lift out of app.js. Each name must be a real declaration in
 // the file, or the epilogue throws ReferenceError at load (a useful tripwire
@@ -125,7 +132,9 @@ function makeTimers() {
  *            consoleErrors, override}}
  */
 export function loadApp(opts = {}) {
-    const source = readFileSync(APP_PATH, 'utf8');
+    const source = SOURCE_FILES
+        .map((name) => readFileSync(join(STATIC_JS, name), 'utf8'))
+        .join('\n');
 
     const localStorage = makeLocalStorage(opts.localStorage || {});
     const consoleErrors = [];

--- a/tests/test_pages.py
+++ b/tests/test_pages.py
@@ -1,0 +1,80 @@
+"""The server-rendered HTML pages.
+
+These are thin -- each route just renders a template -- but the templates share
+a partial and each pulls a different pair of scripts, so a rename or a dropped
+`<script>` tag would otherwise only surface in the browser.
+"""
+
+
+def test_index_renders(client):
+    res = client.get("/")
+    assert res.status_code == 200
+    assert "text/html" in res.headers["content-type"]
+
+
+def test_settings_page_renders(client):
+    res = client.get("/settings")
+    assert res.status_code == 200
+    assert "text/html" in res.headers["content-type"]
+
+
+def test_settings_link_replaces_the_settings_modal_on_the_dashboard(client):
+    """The gear is a link to /settings, and the modal it used to open is gone."""
+    body = client.get("/").text
+    assert 'href="/settings"' in body
+    assert 'id="settings-modal"' not in body
+
+
+def test_settings_page_carries_every_settings_control(client):
+    body = client.get("/settings").text
+    for control in (
+        "child-list",
+        "child-new-name",
+        "child-add-btn",
+        "settings-left-name",
+        "settings-right-name",
+        "settings-bottle-type",
+        "settings-bottle-unit",
+        "settings-save-btn",
+    ):
+        assert f'id="{control}"' in body, control
+
+
+def test_gear_navigates_from_the_dashboard_but_marks_position_on_settings(client):
+    """Both headers show the gear, but only the dashboard's one navigates.
+
+    A self-link on /settings would reload the page and drop unsaved preference
+    edits, so there it is a current-page marker instead.
+    """
+    dashboard = client.get("/").text
+    assert '<a href="/settings" id="settings-btn"' in dashboard
+
+    settings = client.get("/settings").text
+    assert 'id="settings-btn"' in settings
+    assert 'aria-current="page"' in settings
+
+
+def test_settings_page_has_no_cancel_and_offers_a_way_back(client):
+    """Cancel was a modal idiom; the back link replaces it."""
+    body = client.get("/settings").text
+    assert "modal-close" not in body
+    assert 'href="/"' in body
+
+
+def test_both_pages_include_the_shared_confirm_modal(client):
+    """The migration offer runs from /settings, the bulk re-assign from the
+    dashboard, and both drive the same confirmation markup."""
+    for path in ("/", "/settings"):
+        assert 'id="child-confirm-modal"' in client.get(path).text, path
+
+
+def test_each_page_loads_common_plus_its_own_script(client):
+    dashboard = client.get("/").text
+    assert "/static/js/common.js" in dashboard
+    assert "/static/js/app.js" in dashboard
+    assert "/static/js/settings.js" not in dashboard
+
+    settings = client.get("/settings").text
+    assert "/static/js/common.js" in settings
+    assert "/static/js/settings.js" in settings
+    assert "/static/js/app.js" not in settings


### PR DESCRIPTION
Closes #54.

Settings moves out of a modal and onto `/settings`. The header gear navigates there instead of opening the modal, and a `← Back to Dashboard` link returns. Section contents and order are unchanged — the page is the modal's contents with the modal chrome removed.

## Behavior

- **`Cancel` is gone.** It was a modal idiom; the back link covers it.
- **`Save` is disabled until something changes.** It arms on edit, saves, disables again, and re-arms on the next edit. Clicking it keeps you on the page.
- **The two save models are preserved.** `Children` stays instant-apply and server-backed; breast names and feeding defaults stay deferred until `Save`. Editing the Children controls deliberately does *not* arm `Save`, since those have already persisted.
- **Enter in the new-child field still adds a child** rather than submitting the form. Same guard as before, different failure mode avoided (submitting-and-saving rather than closing the modal).
- **The gear on `/settings` is a location marker, not a link.** A self-link would reload the page and silently discard unsaved preference edits — the exact failure this issue set out to fix. It's `aria-current="page"`, dimmed, non-interactive.

## The script split

`app.js` ran a single `DOMContentLoaded` that unconditionally looked up dozens of dashboard-only elements, so loading it on a second page would throw on the first missing node.

The shared layer — API client, toasts, theme, modal plumbing, stored preferences, and the child-profile subsystem — moves to `common.js`, loaded by both pages. `app.js` (2252 → 1677 lines) and the new `settings.js` layer their own page on top.

Two seams keep `common.js` page-agnostic:

| Hook | Why |
|---|---|
| `onChildDataChanged` | `refreshChildUI()` called `renderExportChildOptions()` and `loadDashboard()` directly |
| `onModalOpen` / `onModalClose` | `openModal()`/`closeModal()` carried feeding, diaper, and health branches that only exist on the dashboard |

Dashboard-owned render functions in `common.js` no-op when their element is absent instead of throwing.

## Two corrections to the issue

Both are [written up in full on #54](https://github.com/pid1/puffin/issues/54#issuecomment-5026493044).

**`child-confirm-modal` is not settings-only.** The issue says it "is only reachable from within Settings." It isn't — the bulk re-assign from the *Unassigned logs* view drives the same markup from the dashboard. Moving it as described would have broken that flow with a null dereference. It's now a Jinja partial (`templates/_child_confirm_modal.html`) included by both pages, and `initChildProfiles()` splits into `initChildSettings()` / `initChildDashboard()` along the same line.

**The split wasn't mechanical.** `loadChildren()` and `refreshChildUI()` both reached into dashboard-only DOM, and `addChild → offerMigration → runBulkAssign → refreshChildUI` crosses the page seam — hence the hooks above.

## Test harness

`harness.mjs` hardcoded a single source path and would have failed at load: eight exposed functions moved to `common.js`, and its `EXPOSED_FUNCTIONS` list throws `ReferenceError` for any name it can't resolve. It now concatenates `common.js` and `app.js` in `<script>` order, reproducing the shared scope the browser gives these classic scripts.

Adds `tests/test_pages.py` — the first coverage for the HTML routes, since previously neither `/` nor any template was tested.

## Verification

- **170 Python tests** (was 162), **33 JS tests**, ruff clean.
- Driven in a browser, both pages, light and dark: `Save` lifecycle including the Children-don't-arm-it case, Enter-to-add, child delete through the shared confirm modal, and — on the dashboard — feeding/health/export modals opening and resetting, export child options, child switcher, and timeline. No console errors on either page.
- Cross-page check: setting the left breast name to `Lefty` on `/settings` renders as `🤱 Lefty` on the dashboard.

## Deliberately not done

- **`defaultBottleUnit` is still unprefixed.** Normalizing it needs a read-old-write-new migration, or every existing user silently reverts to `oz`. The issue marked this optional.
- **No `beforeunload` guard.** Left to the implementer by the issue; for four short preference fields the friction outweighs the risk.

## One styling deviation

Section titles get `margin-top: 28px` (collapsing against the preceding `.form-group`'s 16px, so the gap is 28px, not 44px). Without the modal framing them the three sections ran together. This is the only styling change beyond porting the contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
