### PR TITLE
Per-child visibility for dashboard quick add buttons

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -148,7 +148,11 @@ body {
 /* Quick action buttons */
 .quick-actions {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    /* Column count follows how many types the selected child shows, set on the
+       element by applyQuickAddVisibility, so the remaining buttons fill the row
+       instead of leaving gaps. Defaults to 3; the mobile rule below sets the
+       columns directly and still wins there, so small screens always stack. */
+    grid-template-columns: repeat(var(--qa-cols, 3), 1fr);
     gap: 12px;
     margin-bottom: 20px;
 }
@@ -186,7 +190,8 @@ body {
 /* ===== Cards ===== */
 .summary-cards {
     display: grid;
-    grid-template-columns: repeat(3, 1fr);
+    /* Mirrors .quick-actions: --sc-cols tracks the visible card count. */
+    grid-template-columns: repeat(var(--sc-cols, 3), 1fr);
     gap: 12px;
     margin-bottom: 24px;
 }
@@ -761,6 +766,20 @@ body {
     margin-top: 28px;
 }
 
+/* Splits the two save models apart: everything above applies immediately
+   (Children), everything below waits for Save (per-device preferences). The
+   divider carries its own spacing, so the section title after it opts out of
+   the 28px above to avoid doubling the gap. */
+.settings-divider {
+    border: none;
+    border-top: 1px solid var(--border);
+    margin: 28px 0 20px;
+}
+
+.settings-divider + .settings-section-title {
+    margin-top: 0;
+}
+
 /* ===== Child Profiles ===== */
 .sr-only {
     position: absolute;
@@ -829,6 +848,7 @@ body {
     display: flex;
     align-items: center;
     gap: 8px;
+    flex-wrap: wrap;
     padding: 8px 0;
     border-bottom: 1px solid var(--border);
 }
@@ -838,6 +858,27 @@ body {
     flex: 1;
     min-width: 0;
 }
+
+/* Quick add toggles wrap onto their own line under the name and actions. */
+.quick-add-toggles {
+    flex-basis: 100%;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.quick-add-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    min-height: 44px;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    cursor: pointer;
+}
+
+.quick-add-toggle input { cursor: pointer; }
+.quick-add-toggle input:disabled { cursor: default; }
 
 .child-add-row {
     display: flex;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1608,8 +1608,38 @@ function timeAgo(isoStr) {
     return formatShortDate(isoStr);
 }
 
+/**
+ * Show only the quick add buttons and summary cards enabled for the child on
+ * screen, hiding the rest so the remaining ones reflow to fill the row.
+ *
+ * Display-only: hidden types are still fetched, counted, logged, exported, and
+ * shown in the calendar below -- this trims the action row and card row and
+ * nothing else. The unassigned and whole-install views (currentChildId() null)
+ * always show everything, since there is no profile to configure.
+ */
+function applyQuickAddVisibility() {
+    const enabled = getEnabledQuickAddTypes(currentChildId());
+    QUICK_ADD_TYPES.forEach(t => {
+        const on = enabled.includes(t.key);
+        const btn = document.querySelector(`.quick-actions [data-modal="${t.modal}"]`);
+        if (btn) btn.classList.toggle('hidden', !on);
+        const card = document.querySelector(`.summary-cards .${t.cardClass}`);
+        if (card) card.classList.toggle('hidden', !on);
+    });
+    // Collapse the grids to the visible count so the survivors fill the row
+    // rather than leaving the hidden columns as gaps. The mobile media query
+    // still forces a single column underneath this.
+    const actions = document.querySelector('.quick-actions');
+    const cards = document.querySelector('.summary-cards');
+    if (actions) actions.style.setProperty('--qa-cols', enabled.length);
+    if (cards) cards.style.setProperty('--sc-cols', enabled.length);
+}
+
 async function loadDashboard() {
     try {
+        // Runs before the fetch so the visible set matches the selected child
+        // immediately, even if the request is slow or fails.
+        applyQuickAddVisibility();
         const dateStr = toDateString(currentDate);
         const data = await api.get(`/api/dashboard?date=${dateStr}${childQuery()}`);
 

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -94,6 +94,67 @@ function getBreastNames() {
     };
 }
 
+/* ===== Quick Add Visibility (per child, per device) ===== */
+// Which quick add buttons -- and their matching summary cards -- a child shows
+// on the dashboard. One entry per dashboard quick action; the single source of
+// truth shared by the dashboard (which shows/hides buttons and cards from it)
+// and the settings checkboxes (one toggle per entry). `key` is what gets
+// stored; `modal`/`cardClass` are how the dashboard finds the markup.
+const QUICK_ADD_TYPES = [
+    { key: 'diaper',  label: 'Diaper',  modal: 'diaper-modal',  cardClass: 'card-diaper' },
+    { key: 'feeding', label: 'Feeding', modal: 'feeding-modal', cardClass: 'card-feeding' },
+    { key: 'health',  label: 'Health',  modal: 'health-modal',  cardClass: 'card-health' },
+];
+const QUICK_ADD_KEYS = QUICK_ADD_TYPES.map(t => t.key);
+const QUICK_ADD_KEY_PREFIX = 'puffin-quick-add-';
+
+function quickAddStorageKey(childId) {
+    return `${QUICK_ADD_KEY_PREFIX}${childId}`;
+}
+
+/**
+ * The quick add types enabled for a child, as an array of keys in registry
+ * order.
+ *
+ * Visibility is per device, stored in localStorage keyed by child id. A
+ * missing, unparseable, non-array, or empty value all mean "everything
+ * enabled" -- so existing children, and every install that upgrades, see no
+ * change until something is explicitly turned off. Only a concrete child is
+ * ever filtered: the whole-install and unassigned views pass childId null and
+ * always get the full set.
+ */
+function getEnabledQuickAddTypes(childId) {
+    if (typeof childId !== 'number') return [...QUICK_ADD_KEYS];
+    const raw = localStorage.getItem(quickAddStorageKey(childId));
+    if (!raw) return [...QUICK_ADD_KEYS];
+    let stored;
+    try {
+        stored = JSON.parse(raw);
+    } catch (err) {
+        console.error('Discarding corrupt quick-add visibility:', err);
+        return [...QUICK_ADD_KEYS];
+    }
+    if (!Array.isArray(stored)) return [...QUICK_ADD_KEYS];
+    // Filter through the registry so order is stable and any unknown key (a
+    // type since renamed or removed) can't drive the UI. An empty result --
+    // nothing recognised -- falls back to all-on rather than an empty dashboard.
+    const enabled = QUICK_ADD_KEYS.filter(k => stored.includes(k));
+    return enabled.length ? enabled : [...QUICK_ADD_KEYS];
+}
+
+function setEnabledQuickAddTypes(childId, keys) {
+    const enabled = QUICK_ADD_KEYS.filter(k => keys.includes(k));
+    // Never persist an empty set. The settings UI already blocks unchecking the
+    // last type, but a stray empty write would read back as "all enabled" and
+    // silently re-enable everything on the next load, so refuse it here too.
+    if (!enabled.length) return;
+    localStorage.setItem(quickAddStorageKey(childId), JSON.stringify(enabled));
+}
+
+function clearQuickAddTypes(childId) {
+    localStorage.removeItem(quickAddStorageKey(childId));
+}
+
 /* ===== Child Profiles ===== */
 // Profiles themselves live server-side with the logs they label; only the
 // *selection* is per-device, so two phones can view two children at once.
@@ -395,7 +456,47 @@ function renderChildList() {
             <span class="child-row-name">${escapeHtml(c.name)}</span>
             <button type="button" class="btn btn-sm btn-secondary" data-child-rename="${c.id}">Rename</button>
             <button type="button" class="btn btn-sm btn-danger" data-child-delete="${c.id}">Delete</button>
+            ${quickAddTogglesHtml(c.id)}
         </div>`).join('');
+}
+
+/**
+ * The per-child quick add checkboxes, rendered under the name/actions row.
+ * Labels match the dashboard buttons exactly, so no heading is needed. The one
+ * still-checked box is disabled when it's the last one, so the dashboard can
+ * never be emptied of every quick action.
+ */
+function quickAddTogglesHtml(childId) {
+    const enabled = getEnabledQuickAddTypes(childId);
+    const toggles = QUICK_ADD_TYPES.map(t => {
+        const checked = enabled.includes(t.key);
+        const locked = checked && enabled.length === 1;
+        return `<label class="quick-add-toggle">
+            <input type="checkbox" data-quick-add="${childId}" value="${t.key}"
+                   ${checked ? 'checked' : ''}${locked ? ' disabled' : ''}>
+            ${t.label}
+        </label>`;
+    }).join('');
+    return `<div class="quick-add-toggles" data-quick-add-row="${childId}">${toggles}</div>`;
+}
+
+/**
+ * Persist a quick add toggle the instant it changes -- no Save press, matching
+ * the surrounding add/rename/delete controls. Keeps the "at least one enabled"
+ * rule enforced by disabling whichever box is the last one still checked.
+ */
+function persistQuickAddToggle(childId, changedBox) {
+    const boxes = [...document.querySelectorAll(`[data-quick-add="${childId}"]`)];
+    const checked = boxes.filter(b => b.checked);
+    if (checked.length === 0) {
+        // The last box is normally disabled, so reaching zero shouldn't happen;
+        // restore it rather than persist an empty (which reads back as all-on).
+        changedBox.checked = true;
+        showToast('At least one type must be enabled');
+        return;
+    }
+    setEnabledQuickAddTypes(childId, checked.map(b => b.value));
+    boxes.forEach(b => { b.disabled = b.checked && checked.length === 1; });
 }
 
 function startChildRename(childId) {
@@ -437,6 +538,9 @@ function confirmChildDelete(childId) {
         onPrimary: async () => {
             try {
                 await api.del(`/api/children/${childId}`);
+                // The child's per-device visibility prefs die with the profile,
+                // so a recycled id can't inherit a deleted child's toggles.
+                clearQuickAddTypes(childId);
                 closeModal('child-confirm-modal');
                 await refreshChildUI();
                 showToast(`${child.name} deleted — their logs are now unassigned`);
@@ -467,6 +571,17 @@ function initChildSettings() {
         else if (btn.dataset.childRenameSave) saveChildRename(parseInt(btn.dataset.childRenameSave, 10));
         else if (btn.dataset.childRenameCancel) renderChildList();
         else if (btn.dataset.childDelete) confirmChildDelete(parseInt(btn.dataset.childDelete, 10));
+    });
+
+    // Quick add checkboxes autosave on toggle. They fire `change`, which the
+    // click handler above never sees; and they deliberately stay out of the
+    // Save-armed preferences, since they persist on their own like the rest of
+    // the Children section.
+    document.getElementById('child-list').addEventListener('change', (e) => {
+        const box = e.target;
+        if (box.matches && box.matches('input[data-quick-add]')) {
+            persistQuickAddToggle(parseInt(box.dataset.quickAdd, 10), box);
+        }
     });
 }
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -35,6 +35,15 @@
                 <input type="text" id="child-new-name" maxlength="30" placeholder="First name">
                 <button type="button" id="child-add-btn" class="btn btn-sm btn-secondary">+ Add a child</button>
             </div>
+
+            <!--
+              Everything above (children, including their quick add toggles)
+              saves immediately. Everything below is a per-device preference
+              that only persists when Save is pressed; the divider and hint mark
+              that boundary so the two behaviours don't read as one form.
+            -->
+            <hr class="settings-divider">
+            <p class="settings-hint">These preferences apply to this device and take effect when you press Save.</p>
             <h3 class="settings-section-title">Breast Names</h3>
             <div class="form-group">
                 <label for="settings-left-name">Left breast name</label>

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -43,6 +43,9 @@ const EXPOSED_FUNCTIONS = [
     'storeSelectedChild',
     'readStoredChild',
     'validateBottleAmountUnit',
+    'getEnabledQuickAddTypes',
+    'setEnabledQuickAddTypes',
+    'clearQuickAddTypes',
     // DOM-driven (only callable when loadApp({ dom: true }))
     'startTimer',
     'endTimer',
@@ -65,7 +68,7 @@ const EXPOSED_STATE = [
     'lastKnownToday',
 ];
 
-const EXPOSED_CONSTANTS = ['UNASSIGNED_VIEW', 'SELECTED_CHILD_KEY'];
+const EXPOSED_CONSTANTS = ['UNASSIGNED_VIEW', 'SELECTED_CHILD_KEY', 'QUICK_ADD_KEYS'];
 
 // Reassignable function bindings a test can stub to isolate the function under
 // test from its heavier collaborators (fetch + render cascades).

--- a/tests/js/quick-add-visibility.test.mjs
+++ b/tests/js/quick-add-visibility.test.mjs
@@ -1,0 +1,87 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadApp } from './harness.mjs';
+
+// Per-child quick add visibility is stored per device in localStorage, keyed
+// by child id. getEnabledQuickAddTypes is the read primitive the dashboard and
+// the settings checkboxes both trust; its whole contract is "when in doubt,
+// show everything", so a missing/corrupt/empty value can never blank the
+// dashboard. These lock that contract and the round-trip through setter/clear.
+
+const KEY = (id) => `puffin-quick-add-${id}`;
+
+function app(store = {}) {
+    return loadApp({ localStorage: store });
+}
+
+test('all keys when nothing is stored for the child', () => {
+    const a = app();
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(1), a.constants.QUICK_ADD_KEYS);
+});
+
+test('a non-number child (unassigned / whole-install view) always gets all keys', () => {
+    const a = app({ [KEY('null')]: '["health"]' }); // must not be consulted
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(null), a.constants.QUICK_ADD_KEYS);
+});
+
+test('a stored subset is honoured, in registry order', () => {
+    // Stored out of order on purpose; read back canonicalised.
+    const a = app({ [KEY(3)]: '["health","diaper"]' });
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(3), ['diaper', 'health']);
+});
+
+test('a single stored type is a valid state, not treated as empty', () => {
+    const a = app({ [KEY(3)]: '["health"]' });
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(3), ['health']);
+});
+
+test('unknown keys are dropped', () => {
+    const a = app({ [KEY(3)]: '["feeding","sleep","bogus"]' });
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(3), ['feeding']);
+});
+
+test('an all-unknown set falls back to all keys rather than blanking', () => {
+    const a = app({ [KEY(3)]: '["sleep","bogus"]' });
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(3), a.constants.QUICK_ADD_KEYS);
+});
+
+test('an empty array falls back to all keys', () => {
+    const a = app({ [KEY(3)]: '[]' });
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(3), a.constants.QUICK_ADD_KEYS);
+});
+
+test('a non-array value falls back to all keys', () => {
+    const a = app({ [KEY(3)]: '"health"' });
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(3), a.constants.QUICK_ADD_KEYS);
+});
+
+test('malformed JSON falls back to all keys and is logged, not thrown', () => {
+    const a = app({ [KEY(3)]: '{oops' });
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(3), a.constants.QUICK_ADD_KEYS);
+    assert.equal(a.consoleErrors.length, 1);
+    assert.match(a.consoleErrors[0], /quick-add/i);
+});
+
+test('set then get round-trips, and canonicalises order', () => {
+    const a = app();
+    a.fns.setEnabledQuickAddTypes(7, ['health', 'diaper']);
+    assert.equal(a.localStorage.getItem(KEY(7)), '["diaper","health"]');
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(7), ['diaper', 'health']);
+});
+
+test('set refuses an empty (or all-unknown) set, leaving storage untouched', () => {
+    const a = app();
+    a.fns.setEnabledQuickAddTypes(7, []);
+    assert.equal(a.localStorage.getItem(KEY(7)), null);
+    a.fns.setEnabledQuickAddTypes(7, ['nope']);
+    assert.equal(a.localStorage.getItem(KEY(7)), null);
+    // Which still reads as all-on, never empty.
+    assert.deepEqual(a.fns.getEnabledQuickAddTypes(7), a.constants.QUICK_ADD_KEYS);
+});
+
+test('clear removes a child key without touching siblings', () => {
+    const a = app({ [KEY(1)]: '["health"]', [KEY(2)]: '["feeding"]' });
+    a.fns.clearQuickAddTypes(1);
+    assert.equal(a.localStorage.getItem(KEY(1)), null);
+    assert.equal(a.localStorage.getItem(KEY(2)), '["feeding"]');
+});


### PR DESCRIPTION
Closes #56.

Adds per-child toggles for which quick add buttons — `Diaper`, `Feeding`, `Health` — appear on the dashboard, configured from the Settings child list. Hiding a type removes its quick add button **and** its summary card; the remaining ones reflow to fill the row.

## Behavior
- **Display-only.** Logs, history, exports, and API responses are unchanged — `crud.get_activities` / `crud.get_dashboard` still compute all types for every child. Filtering happens entirely in the client render layer.
- **Per device, defaulting to all-on.** Stored in `localStorage` keyed `puffin-quick-add-{childId}`. Missing/corrupt/empty ⇒ all enabled, so existing installs see no change until a type is turned off. The unassigned and whole-install views always show everything.
- **At least one enabled.** The last still-checked box is disabled, so a child's dashboard can never be emptied of every quick action.

## Implementation
- **`QUICK_ADD_TYPES` registry** (`common.js`) is the single source of truth the dashboard (button/card visibility) and the settings checkboxes (one toggle per type) both consume.
- **Settings checkboxes** render under each child's name and **autosave on toggle**, matching the surrounding add/rename/delete controls — and deliberately stay out of the `Save`-armed preference group. A divider + hint now mark that boundary between the immediately-applied Children section and the Save-deferred preferences.
- **Delete cleanup:** a child's stored prefs are cleared when the profile is deleted, so a recycled id can't inherit them.
- The in-progress feeding timer (`#timer-section`) is independent of the feeding button and needs no changes — a running timer stays fully visible and functional even with `Feeding` disabled.

## Testing
- 12 new cases in `tests/js/quick-add-visibility.test.mjs` covering the fallback contract (missing/corrupt/non-array/empty/unknown-key → all-on), single-type validity, registry-order canonicalization, set/clear round-trips, and the refuse-empty-write guard.
- Full suite green: **170 Python + 45 JS**.
- Browser-verified end to end: autosave with no Save press, last-box lock, `Save` stays un-armed, dashboard filter + reflow, Health modal still opens, per-child independence, new-child defaults, delete-clears-key, and persistence across reload.