### PR TITLE
Scope Health card temperature to viewed date and record its unit

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -455,17 +455,30 @@ def add_saved_medication(db: Session, name: str) -> bool:
 # --- Temperature Readings ---
 
 
+def format_temperature(temperature_celsius: float, unit: str | None) -> str:
+    """Render a stored Celsius reading in its recorded unit ("C" or "F").
+
+    Readings are always stored in Celsius; ``unit`` records how the value was
+    entered so it can be displayed back in the same unit.
+    """
+    if (unit or "C").upper() == "F":
+        return f"{round(temperature_celsius * 9 / 5 + 32, 1)}°F"
+    return f"{round(temperature_celsius, 1)}°C"
+
+
 def create_temperature(
     db: Session,
     timestamp: datetime | None,
     temperature_celsius: float,
     location: str | None,
     notes: str | None,
+    unit: str = "F",
     child_id: int | None = None,
 ) -> TemperatureReading:
     obj = TemperatureReading(
         timestamp=timestamp or datetime.now(UTC),
         temperature_celsius=temperature_celsius,
+        unit=unit,
         location=location,
         notes=notes,
         child_id=child_id,
@@ -743,7 +756,8 @@ def get_activities(
             }
         )
     for t in get_temperatures(db, start_date=start, end_date=end, limit=limit, child=child):
-        temp_f = round(t.temperature_celsius * 9 / 5 + 32, 1)
+        # Render in the unit the reading was recorded in (stored as Celsius).
+        temp_str = format_temperature(t.temperature_celsius, t.unit)
         activities.append(
             {
                 "type": "temperature",
@@ -752,8 +766,8 @@ def get_activities(
                 "id": t.id,
                 "emoji": "\U0001f321\ufe0f",
                 "label": "Temperature",
-                "detail": f"{temp_f}\u00b0F",
-                "summary": f"Temp: {temp_f}\u00b0F",
+                "detail": temp_str,
+                "summary": f"Temp: {temp_str}",
                 "notes": t.notes,
             }
         )
@@ -787,7 +801,25 @@ def get_dashboard(db: Session, date_str: str | None = None, child: ChildFilter =
 
     last_diaper = _latest(DiaperChange)
     last_feeding = _latest(Feeding)
-    last_temp = _latest(TemperatureReading)
+
+    # Unlike the always-latest entries above, the last temperature is scoped to
+    # the viewed calendar day (issue #58): the most recent reading for the
+    # selected date, or None if that day has none. Defaults to today when no
+    # date is supplied.
+    temp_day = date_str or now.astimezone(_get_local_tz()).strftime("%Y-%m-%d")
+    t_start, t_end = _day_bounds(temp_day)
+    temp_stmt = (
+        select(TemperatureReading)
+        .where(
+            TemperatureReading.timestamp >= t_start,
+            TemperatureReading.timestamp < t_end,
+        )
+        .order_by(TemperatureReading.timestamp.desc())
+        .limit(1)
+    )
+    last_temp = db.execute(
+        _child_where(temp_stmt, TemperatureReading.child_id, child)
+    ).scalar_one_or_none()
 
     # Recent activities (last 3 days, excluding future)
     three_days_ago = now - timedelta(days=3)

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -183,6 +183,22 @@ def _run_migrations(bind=None) -> None:
             conn.execute(text(f"CREATE INDEX IF NOT EXISTS {index} ON {table} (child_id)"))
             conn.commit()
 
+        # Temperature readings gain a ``unit`` column recording how each reading
+        # was entered/displayed. Legacy rows predate this and have no known
+        # entry unit; the stored value is Celsius, so they are backfilled to
+        # 'C' — displaying the true canonical value without inventing an entry
+        # unit we can't recover. See issue #58.
+        insp = inspect(conn)
+        if insp.has_table("temperature_readings"):
+            temp_cols = {c["name"] for c in insp.get_columns("temperature_readings")}
+            if "unit" not in temp_cols:
+                conn.execute(
+                    text(
+                        "ALTER TABLE temperature_readings ADD COLUMN unit TEXT NOT NULL DEFAULT 'C'"
+                    )
+                )
+                conn.commit()
+
         insp = inspect(conn)
         if not insp.has_table("medications"):
             return

--- a/src/puffin/models.py
+++ b/src/puffin/models.py
@@ -129,6 +129,9 @@ class TemperatureReading(Base):
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     timestamp: Mapped[datetime] = mapped_column(_TZ_DATETIME, nullable=False, default=_utcnow)
     temperature_celsius: Mapped[float] = mapped_column(Float, nullable=False)
+    # The unit the reading was entered/displayed in ("C" or "F"). The value is
+    # always stored in Celsius above; this only records how to render it back.
+    unit: Mapped[str] = mapped_column(String, nullable=False, default="F")
     location: Mapped[str | None] = mapped_column(
         String, nullable=True
     )  # rectal, oral, axillary, temporal

--- a/src/puffin/routers/dashboard.py
+++ b/src/puffin/routers/dashboard.py
@@ -278,11 +278,11 @@ def export_data(
             pdf,
             "Temperature Readings",
             *with_child(
-                ["Time", "Temp (°C)", "Location", "Notes"],
+                ["Time", "Temp", "Location", "Notes"],
                 [
                     [
                         _fmt_ts(t.timestamp, local_tz),
-                        str(t.temperature_celsius),
+                        _fmt_temperature(t),
                         str(t.location) if t.location else "",
                         t.notes or "",
                     ]
@@ -390,7 +390,9 @@ def export_data(
     writer.writerow([])
     writer.writerow(["--- Temperature Readings ---"])
     writer.writerow(
-        header(["id", "timestamp", "temperature_celsius", "location", "notes", "created_at"])
+        header(
+            ["id", "timestamp", "temperature_celsius", "unit", "location", "notes", "created_at"]
+        )
     )
     for t in temperatures:
         writer.writerow(
@@ -399,6 +401,7 @@ def export_data(
                     t.id,
                     ts(t.timestamp),
                     t.temperature_celsius,
+                    t.unit,
                     t.location,
                     t.notes,
                     ts(t.created_at),
@@ -418,6 +421,11 @@ def export_data(
 def _fmt_ts(ts: datetime, tz) -> str:
     """Format a stored UTC datetime in the local zone for the PDF."""
     return ts.astimezone(tz).strftime("%Y-%m-%d %H:%M") if ts else ""
+
+
+def _fmt_temperature(t) -> str:
+    """Render a temperature reading in its recorded unit for the PDF."""
+    return crud.format_temperature(t.temperature_celsius, t.unit)
 
 
 def _build_date_range_label(start: datetime | None, end: datetime | None) -> str:

--- a/src/puffin/routers/health.py
+++ b/src/puffin/routers/health.py
@@ -114,6 +114,7 @@ def create_temperature(data: TemperatureCreate, db: Session = Depends(get_db)):
         db,
         timestamp=data.timestamp,
         temperature_celsius=data.temperature_celsius,
+        unit=data.unit.value,
         location=data.location.value if data.location else None,
         notes=data.notes,
         child_id=data.child_id,
@@ -149,6 +150,8 @@ def update_temperature(temp_id: int, data: TemperatureUpdate, db: Session = Depe
         updates["timestamp"] = data.timestamp
     if data.temperature_celsius is not None:
         updates["temperature_celsius"] = data.temperature_celsius
+    if data.unit is not None:
+        updates["unit"] = data.unit.value
     if data.location is not None:
         updates["location"] = data.location.value
     if data.notes is not None:

--- a/src/puffin/schemas.py
+++ b/src/puffin/schemas.py
@@ -49,6 +49,11 @@ class TemperatureLocation(StrEnum):
     temporal = "temporal"
 
 
+class TemperatureUnit(StrEnum):
+    celsius = "C"
+    fahrenheit = "F"
+
+
 class DosageUnit(StrEnum):
     ml = "mL"
     tsp = "tsp(s)"
@@ -265,6 +270,7 @@ class MedicationResponse(BaseModel):
 class TemperatureCreate(BaseModel):
     timestamp: datetime | None = None
     temperature_celsius: float = Field(ge=_MIN_TEMP_C, le=_MAX_TEMP_C)
+    unit: TemperatureUnit = TemperatureUnit.fahrenheit
     location: TemperatureLocation | None = None
     notes: str | None = None
     child_id: int | None = None
@@ -273,6 +279,7 @@ class TemperatureCreate(BaseModel):
 class TemperatureUpdate(BaseModel):
     timestamp: datetime | None = None
     temperature_celsius: float | None = Field(None, ge=_MIN_TEMP_C, le=_MAX_TEMP_C)
+    unit: TemperatureUnit | None = None
     location: TemperatureLocation | None = None
     notes: str | None = None
     child_id: int | None = None
@@ -284,6 +291,7 @@ class TemperatureResponse(BaseModel):
     id: int
     timestamp: datetime
     temperature_celsius: float
+    unit: TemperatureUnit = TemperatureUnit.celsius
     location: TemperatureLocation | None
     notes: str | None
     child_id: int | None = None

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1023,6 +1023,7 @@ function initForms() {
         try {
             await api.post('/api/temperatures', {
                 temperature_celsius: Math.round(tempValue * 10) / 10,
+                unit: unit.toUpperCase(),
                 location,
                 notes,
                 timestamp,
@@ -1248,15 +1249,18 @@ function buildMedicationEditFields(data) {
 }
 
 function buildTemperatureEditFields(data) {
-    const tempF = Math.round((data.temperature_celsius * 9 / 5 + 32) * 10) / 10;
+    const unit = (data.unit || 'C').toUpperCase();
+    const tempValue = unit === 'F'
+        ? Math.round((data.temperature_celsius * 9 / 5 + 32) * 10) / 10
+        : Math.round(data.temperature_celsius * 10) / 10;
     return `
         <div class="form-group">
             <label for="edit-temp-value">Temperature</label>
             <div class="input-group">
-                <input type="number" id="edit-temp-value" step="0.1" value="${tempF}" required>
+                <input type="number" id="edit-temp-value" step="0.1" value="${tempValue}" required>
                 <select id="edit-temp-unit">
-                    <option value="f">°F</option>
-                    <option value="c">°C</option>
+                    <option value="f" ${unit === 'F' ? 'selected' : ''}>°F</option>
+                    <option value="c" ${unit === 'C' ? 'selected' : ''}>°C</option>
                 </select>
             </div>
         </div>
@@ -1329,6 +1333,7 @@ function buildEditBody(type) {
             const unit = document.getElementById('edit-temp-unit').value;
             if (unit === 'f') tempValue = (tempValue - 32) * 5 / 9;
             body.temperature_celsius = Math.round(tempValue * 10) / 10;
+            body.unit = unit.toUpperCase();
             const loc = document.getElementById('edit-temp-location').value;
             if (loc) body.location = loc;
             break;
@@ -1658,8 +1663,21 @@ async function loadDashboard() {
             data.last_diaper ? `Last: ${timeAgo(data.last_diaper.timestamp)}` : 'No records';
         document.getElementById('last-feeding').textContent =
             data.last_feeding ? `Last: ${timeAgo(data.last_feeding.timestamp)}` : 'No records';
-        document.getElementById('last-temp').textContent =
-            data.last_temperature ? `${data.last_temperature.temperature_celsius}°C` : 'No readings';
+        // Show the most recent reading for the viewed day in the unit it was
+        // recorded in; render no detail line when the day has no reading.
+        const tempEl = document.getElementById('last-temp');
+        const lastTemp = data.last_temperature;
+        if (lastTemp) {
+            const unit = (lastTemp.unit || 'C').toUpperCase();
+            const value = unit === 'F'
+                ? Math.round((lastTemp.temperature_celsius * 9 / 5 + 32) * 10) / 10
+                : Math.round(lastTemp.temperature_celsius * 10) / 10;
+            tempEl.textContent = `${value}°${unit}`;
+            tempEl.style.display = '';
+        } else {
+            tempEl.textContent = '';
+            tempEl.style.display = 'none';
+        }
 
         // Refresh the calendar day view
         loadDayActivities();

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -35,6 +35,16 @@ def test_pdf_export_survives_smart_quotes_and_emoji(client):
     assert len(resp.content) > 1000
 
 
+def test_pdf_export_renders_temperatures_in_recorded_units(client):
+    """Mixed-unit temperature readings export without error, each in its unit."""
+    client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "F"})
+    client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "C"})
+
+    resp = client.get("/api/export?format=pdf")
+    assert resp.status_code == 200
+    assert resp.content[:5] == b"%PDF-"
+
+
 def test_pdf_uses_the_bundled_unicode_font(client):
     """The bundled DejaVu font should be found and used, not the fallback."""
     assert dashboard._FONT_REGULAR.exists(), "the bundled font is missing from the repo"

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -194,6 +194,77 @@ def test_delete_temperature(client):
     assert client.delete(f"/api/temperatures/{tid}").status_code == 204
 
 
+def test_create_temperature_unit_defaults_to_fahrenheit(client):
+    resp = client.post("/api/temperatures", json={"temperature_celsius": 37.5})
+    assert resp.status_code == 201
+    assert resp.json()["unit"] == "F"
+
+
+def test_create_temperature_persists_explicit_unit(client):
+    resp = client.post("/api/temperatures", json={"temperature_celsius": 37.5, "unit": "C"})
+    assert resp.status_code == 201
+    assert resp.json()["unit"] == "C"
+
+
+def test_update_temperature_unit(client):
+    tid = client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "C"}).json()[
+        "id"
+    ]
+    resp = client.put(f"/api/temperatures/{tid}", json={"unit": "F"})
+    assert resp.status_code == 200
+    assert resp.json()["unit"] == "F"
+
+
+def test_dashboard_last_temperature_scoped_to_viewed_day(client):
+    # A reading yesterday and one today; each day's dashboard reports its own.
+    client.post(
+        "/api/temperatures",
+        json={"temperature_celsius": 37.0, "timestamp": "2026-04-05T12:00:00Z"},
+    )
+    client.post(
+        "/api/temperatures",
+        json={"temperature_celsius": 38.0, "timestamp": "2026-04-06T12:00:00Z"},
+    )
+
+    today = client.get("/api/dashboard?date=2026-04-06").json()
+    assert today["last_temperature"]["temperature_celsius"] == 38.0
+
+    yesterday = client.get("/api/dashboard?date=2026-04-05").json()
+    assert yesterday["last_temperature"]["temperature_celsius"] == 37.0
+
+
+def test_dashboard_last_temperature_none_when_day_has_no_reading(client):
+    client.post(
+        "/api/temperatures",
+        json={"temperature_celsius": 37.0, "timestamp": "2026-04-05T12:00:00Z"},
+    )
+    # A day with no reading returns no last temperature, even though an older
+    # reading exists.
+    data = client.get("/api/dashboard?date=2026-04-06").json()
+    assert data["last_temperature"] is None
+
+
+def test_activity_feed_temperature_renders_recorded_unit(client):
+    client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "F"})
+    client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "C"})
+    activities = client.get("/api/dashboard").json()["recent_activities"]
+    details = {a["detail"] for a in activities if a["type"] == "temperature"}
+    assert details == {"98.6°F", "37.0°C"}
+
+
+def test_dashboard_last_temperature_reports_recorded_unit(client):
+    client.post(
+        "/api/temperatures",
+        json={
+            "temperature_celsius": 37.0,
+            "unit": "F",
+            "timestamp": "2026-04-06T12:00:00Z",
+        },
+    )
+    data = client.get("/api/dashboard?date=2026-04-06").json()
+    assert data["last_temperature"]["unit"] == "F"
+
+
 def test_dashboard(client):
     client.post("/api/diapers", json={"type": "pee"})
     client.post("/api/feedings", json={"feeding_type": "bottle"})

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -196,6 +196,67 @@ def test_migration_adds_amount_unit_to_current_amount_schema(tmp_path):
     assert rows[1] == ("breast_left", None, None)
 
 
+def test_migration_backfills_temperature_unit_as_celsius(tmp_path):
+    """Legacy temperature rows have no recorded unit; the stored value is
+    Celsius, so the migration backfills ``unit`` to 'C' rather than assuming an
+    entry unit it cannot recover. See issue #58.
+    """
+    db_path = tmp_path / "temps_without_unit.db"
+    raw = sqlite3.connect(db_path)
+    raw.executescript(
+        """
+        CREATE TABLE feedings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME NOT NULL,
+            feeding_type TEXT NOT NULL,
+            duration_minutes INTEGER,
+            amount REAL,
+            amount_unit TEXT,
+            notes TEXT,
+            session_id TEXT,
+            bottle_type TEXT,
+            created_at DATETIME
+        );
+        CREATE TABLE temperature_readings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME NOT NULL,
+            temperature_celsius REAL NOT NULL,
+            location TEXT,
+            notes TEXT,
+            created_at DATETIME
+        );
+        INSERT INTO temperature_readings
+            (timestamp, temperature_celsius, location, notes, created_at)
+        VALUES
+            ('2026-04-01 09:00:00', 37.0, NULL, NULL, '2026-04-01 09:00:00'),
+            ('2026-04-02 09:00:00', 38.2, 'oral', NULL, '2026-04-02 09:00:00');
+        """
+    )
+    raw.commit()
+    raw.close()
+
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    try:
+        _run_migrations(bind=engine)
+        _run_migrations(bind=engine)
+        with engine.connect() as conn:
+            cols = {c["name"] for c in inspect(conn).get_columns("temperature_readings")}
+            units = (
+                conn.execute(text("SELECT unit FROM temperature_readings ORDER BY id"))
+                .scalars()
+                .all()
+            )
+    finally:
+        engine.dispose()
+
+    assert "unit" in cols
+    assert units == ["C", "C"]
+
+
 def test_migration_drops_obsolete_dosage_column(legacy_engine):
     """The old NOT NULL ``dosage`` column must go — otherwise new medication
     saves fail with a NOT NULL constraint error (issue #30)."""


### PR DESCRIPTION
Closes #58.

## What changed

The dashboard **Health card** temperature detail line had two problems, both stemming from the fact that the unit a reading was entered in was never stored — the form converted °F → °C on save and discarded the choice:

1. It showed the single **latest reading overall**, ignoring the viewed date.
2. It always labeled the value **°C**, while the activity feed always converted the same value to **°F** — so one reading could appear in two different units in two places, and neither reflected what the parent actually entered.

## Fixes

- **Record the unit per reading.** New `unit` column (`"C"` / `"F"`) on `TemperatureReading`. The value stays canonical Celsius; `unit` only records how to render it back. Wired through the create/edit forms, API schemas, and endpoints.
- **Scope the Health card to the viewed day.** The detail line now shows the most recent reading for the selected date, or renders **no detail line** when that day has none — matching how the diaper/feeding/med counts already behave.
- **Display every surface in the recorded unit.** Health card, activity feed, CSV export (new `unit` column), and PDF export all render via a shared `crud.format_temperature()` helper.
- **Migration.** Adds the `unit` column on startup and backfills legacy rows to **`"C"`** — the canonical stored unit — rather than inventing an entry unit that can't be recovered.

## Decisions worth a look

- **Legacy backfill → `C`.** For pre-existing rows we can't know the original entry unit, and the stored value is Celsius, so `C` shows the true value without asserting anything false. A legacy reading originally typed in °F will now display in °C (same temperature, shown in its stored unit).
- **New-record default → `F`.** When a create request omits `unit`, it defaults to `F`, matching the entry form's default selector (the form always sends the unit explicitly, so this only affects bare API calls). Happy to flip this to `C` for consistency with the backfill if preferred.
- **PDF header** changed from `Temp (°C)` to `Temp`, since the column can now mix units.

## Tests

Added coverage for unit persistence/update, date-scoped `last_temperature` (including the empty-day case), per-unit rendering in the activity feed and PDF, and the `C` migration backfill. Full suite: **179 passing**, ruff clean.
