### PR TITLE
Store temperature as entered and equalize Health card height on mobile

### DIFF
--- a/src/puffin/crud.py
+++ b/src/puffin/crud.py
@@ -455,21 +455,20 @@ def add_saved_medication(db: Session, name: str) -> bool:
 # --- Temperature Readings ---
 
 
-def format_temperature(temperature_celsius: float, unit: str | None) -> str:
-    """Render a stored Celsius reading in its recorded unit ("C" or "F").
+def format_temperature(temperature: float, unit: str | None) -> str:
+    """Render a reading in the unit it was recorded in ("C" or "F").
 
-    Readings are always stored in Celsius; ``unit`` records how the value was
-    entered so it can be displayed back in the same unit.
+    ``temperature`` is stored exactly as entered, so no conversion is needed --
+    only the degree symbol is appended.
     """
-    if (unit or "C").upper() == "F":
-        return f"{round(temperature_celsius * 9 / 5 + 32, 1)}°F"
-    return f"{round(temperature_celsius, 1)}°C"
+    u = (unit or "C").upper()
+    return f"{round(temperature, 1)}°{u if u in ('C', 'F') else 'C'}"
 
 
 def create_temperature(
     db: Session,
     timestamp: datetime | None,
-    temperature_celsius: float,
+    temperature: float,
     location: str | None,
     notes: str | None,
     unit: str = "F",
@@ -477,7 +476,7 @@ def create_temperature(
 ) -> TemperatureReading:
     obj = TemperatureReading(
         timestamp=timestamp or datetime.now(UTC),
-        temperature_celsius=temperature_celsius,
+        temperature=temperature,
         unit=unit,
         location=location,
         notes=notes,
@@ -756,8 +755,8 @@ def get_activities(
             }
         )
     for t in get_temperatures(db, start_date=start, end_date=end, limit=limit, child=child):
-        # Render in the unit the reading was recorded in (stored as Celsius).
-        temp_str = format_temperature(t.temperature_celsius, t.unit)
+        # Render in the unit the reading was recorded in (stored as entered).
+        temp_str = format_temperature(t.temperature, t.unit)
         activities.append(
             {
                 "type": "temperature",

--- a/src/puffin/database.py
+++ b/src/puffin/database.py
@@ -199,6 +199,29 @@ def _run_migrations(bind=None) -> None:
                 )
                 conn.commit()
 
+        # Store temperatures as entered instead of normalized to Celsius: rename
+        # ``temperature_celsius`` to ``temperature`` and reconstruct the entered
+        # value from the recorded ``unit``. Fahrenheit rows are converted back
+        # from their stored Celsius value (best-effort — earlier rounding to
+        # Celsius isn't perfectly reversible); Celsius rows are kept as-is. This
+        # runs after the ``unit`` backfill above, which it depends on. See #60.
+        insp = inspect(conn)
+        if insp.has_table("temperature_readings"):
+            temp_cols = {c["name"] for c in insp.get_columns("temperature_readings")}
+            if "temperature_celsius" in temp_cols and "temperature" not in temp_cols:
+                conn.execute(text("ALTER TABLE temperature_readings ADD COLUMN temperature FLOAT"))
+                conn.execute(
+                    text(
+                        "UPDATE temperature_readings SET temperature = CASE "
+                        "WHEN unit = 'F' THEN ROUND(temperature_celsius * 9.0 / 5.0 + 32, 1) "
+                        "ELSE temperature_celsius END"
+                    )
+                )
+                conn.execute(
+                    text("ALTER TABLE temperature_readings DROP COLUMN temperature_celsius")
+                )
+                conn.commit()
+
         insp = inspect(conn)
         if not insp.has_table("medications"):
             return

--- a/src/puffin/models.py
+++ b/src/puffin/models.py
@@ -128,9 +128,10 @@ class TemperatureReading(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     timestamp: Mapped[datetime] = mapped_column(_TZ_DATETIME, nullable=False, default=_utcnow)
-    temperature_celsius: Mapped[float] = mapped_column(Float, nullable=False)
-    # The unit the reading was entered/displayed in ("C" or "F"). The value is
-    # always stored in Celsius above; this only records how to render it back.
+    # The temperature exactly as the user entered it, in the unit recorded
+    # below — no normalization to Celsius. Interpret it together with ``unit``.
+    temperature: Mapped[float] = mapped_column(Float, nullable=False)
+    # The unit ``temperature`` is expressed in ("C" or "F").
     unit: Mapped[str] = mapped_column(String, nullable=False, default="F")
     location: Mapped[str | None] = mapped_column(
         String, nullable=True

--- a/src/puffin/routers/dashboard.py
+++ b/src/puffin/routers/dashboard.py
@@ -390,9 +390,7 @@ def export_data(
     writer.writerow([])
     writer.writerow(["--- Temperature Readings ---"])
     writer.writerow(
-        header(
-            ["id", "timestamp", "temperature_celsius", "unit", "location", "notes", "created_at"]
-        )
+        header(["id", "timestamp", "temperature", "unit", "location", "notes", "created_at"])
     )
     for t in temperatures:
         writer.writerow(
@@ -400,7 +398,7 @@ def export_data(
                 [
                     t.id,
                     ts(t.timestamp),
-                    t.temperature_celsius,
+                    t.temperature,
                     t.unit,
                     t.location,
                     t.notes,
@@ -425,7 +423,7 @@ def _fmt_ts(ts: datetime, tz) -> str:
 
 def _fmt_temperature(t) -> str:
     """Render a temperature reading in its recorded unit for the PDF."""
-    return crud.format_temperature(t.temperature_celsius, t.unit)
+    return crud.format_temperature(t.temperature, t.unit)
 
 
 def _build_date_range_label(start: datetime | None, end: datetime | None) -> str:

--- a/src/puffin/routers/health.py
+++ b/src/puffin/routers/health.py
@@ -15,6 +15,7 @@ from puffin.schemas import (
     TemperatureCreate,
     TemperatureResponse,
     TemperatureUpdate,
+    _temperature_in_range,
 )
 
 router = APIRouter(tags=["health"])
@@ -113,7 +114,7 @@ def create_temperature(data: TemperatureCreate, db: Session = Depends(get_db)):
     return crud.create_temperature(
         db,
         timestamp=data.timestamp,
-        temperature_celsius=data.temperature_celsius,
+        temperature=data.temperature,
         unit=data.unit.value,
         location=data.location.value if data.location else None,
         notes=data.notes,
@@ -145,11 +146,26 @@ def get_temperature(temp_id: int, db: Session = Depends(get_db)):
 
 @router.put("/api/temperatures/{temp_id}", response_model=TemperatureResponse)
 def update_temperature(temp_id: int, data: TemperatureUpdate, db: Session = Depends(get_db)):
+    existing = crud.get_temperature(db, temp_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Temperature reading not found")
+
+    # A partial update may change the value or the unit independently, so
+    # range-check the resulting (value, unit) pair against the existing row.
+    # (The schema validator only covers the case where both are supplied.)
+    if data.temperature is not None or data.unit is not None:
+        eff_temp = data.temperature if data.temperature is not None else existing.temperature
+        eff_unit = data.unit.value if data.unit is not None else existing.unit
+        if not _temperature_in_range(eff_temp, eff_unit):
+            raise HTTPException(
+                status_code=422, detail=f"temperature out of range for unit {eff_unit}"
+            )
+
     updates = {}
     if data.timestamp is not None:
         updates["timestamp"] = data.timestamp
-    if data.temperature_celsius is not None:
-        updates["temperature_celsius"] = data.temperature_celsius
+    if data.temperature is not None:
+        updates["temperature"] = data.temperature
     if data.unit is not None:
         updates["unit"] = data.unit.value
     if data.location is not None:

--- a/src/puffin/schemas.py
+++ b/src/puffin/schemas.py
@@ -9,8 +9,9 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 # Bounds for the free-numeric log fields.  These are deliberately generous --
 # the goal is to reject transparently impossible input (negative durations, a
 # -500 C body temperature that the PDF export happily renders as -868 F), not
-# to second-guess a real reading.  The frontend converts Fahrenheit to Celsius
-# before posting, so a temperature always arrives in Celsius.
+# to second-guess a real reading.  A temperature is stored as entered, so the
+# raw value may be Celsius or Fahrenheit; ``_temperature_in_range`` converts to
+# Celsius before applying these bounds.
 _MIN_TEMP_C = 20.0  # below profound hypothermia
 _MAX_TEMP_C = 45.0  # above survivable hyperthermia
 _MAX_FEED_MINUTES = 24 * 60
@@ -267,22 +268,47 @@ class MedicationResponse(BaseModel):
 # --- Temperature Schemas ---
 
 
+def _to_celsius(temperature: float, unit: str) -> float:
+    """Convert a raw entered temperature to Celsius for range checks."""
+    return (temperature - 32) * 5 / 9 if unit.upper() == "F" else temperature
+
+
+def _temperature_in_range(temperature: float, unit: str) -> bool:
+    return _MIN_TEMP_C <= _to_celsius(temperature, unit) <= _MAX_TEMP_C
+
+
 class TemperatureCreate(BaseModel):
     timestamp: datetime | None = None
-    temperature_celsius: float = Field(ge=_MIN_TEMP_C, le=_MAX_TEMP_C)
+    temperature: float
     unit: TemperatureUnit = TemperatureUnit.fahrenheit
     location: TemperatureLocation | None = None
     notes: str | None = None
     child_id: int | None = None
 
+    @model_validator(mode="after")
+    def _check_range(self) -> Self:
+        if not _temperature_in_range(self.temperature, self.unit.value):
+            raise ValueError(f"temperature out of range for unit {self.unit.value}")
+        return self
+
 
 class TemperatureUpdate(BaseModel):
     timestamp: datetime | None = None
-    temperature_celsius: float | None = Field(None, ge=_MIN_TEMP_C, le=_MAX_TEMP_C)
+    temperature: float | None = None
     unit: TemperatureUnit | None = None
     location: TemperatureLocation | None = None
     notes: str | None = None
     child_id: int | None = None
+
+    @model_validator(mode="after")
+    def _check_range(self) -> Self:
+        # Only validatable here when both are supplied; a partial update (e.g.
+        # temperature without unit) is range-checked in the router against the
+        # existing row's unit.
+        if self.temperature is not None and self.unit is not None:
+            if not _temperature_in_range(self.temperature, self.unit.value):
+                raise ValueError(f"temperature out of range for unit {self.unit.value}")
+        return self
 
 
 class TemperatureResponse(BaseModel):
@@ -290,7 +316,7 @@ class TemperatureResponse(BaseModel):
 
     id: int
     timestamp: datetime
-    temperature_celsius: float
+    temperature: float
     unit: TemperatureUnit = TemperatureUnit.celsius
     location: TemperatureLocation | None
     notes: str | None

--- a/src/puffin/seed.py
+++ b/src/puffin/seed.py
@@ -240,7 +240,8 @@ def generate_temperatures(
         temps.append(
             TemperatureReading(
                 timestamp=t,
-                temperature_celsius=temp_c,
+                temperature=temp_c,
+                unit="C",
                 location=location,
                 notes=None,
                 created_at=t,

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -220,6 +220,10 @@ body {
 
 .card-detail {
     font-size: 0.8rem;
+    line-height: 1.2;
+    /* Reserve one line even when empty (e.g. Health card with no reading for
+       the day) so every summary card keeps the same height on mobile. */
+    min-height: 1.2em;
     color: var(--text-secondary);
     margin-top: 4px;
 }

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1006,23 +1006,19 @@ function initForms() {
     // Temperature form
     document.getElementById('temperature-form').addEventListener('submit', async (e) => {
         e.preventDefault();
-        let tempValue = parseFloat(document.getElementById('temp-value').value);
+        const tempValue = parseFloat(document.getElementById('temp-value').value);
         const unit = document.getElementById('temp-unit').value;
         const location = document.getElementById('temp-location').value || undefined;
         const notes = document.getElementById('temp-notes').value || undefined;
         const timestampInput = document.getElementById('temp-timestamp').value;
         const timestamp = timestampInput ? new Date(timestampInput).toISOString() : undefined;
 
-        // Convert F to C if needed
-        if (unit === 'f') {
-            tempValue = (tempValue - 32) * 5 / 9;
-        }
-
         const submitBtn = e.target.querySelector('button[type="submit"]');
         submitBtn.disabled = true;
         try {
+            // Store the value as entered, in the chosen unit — no conversion.
             await api.post('/api/temperatures', {
-                temperature_celsius: Math.round(tempValue * 10) / 10,
+                temperature: Math.round(tempValue * 10) / 10,
                 unit: unit.toUpperCase(),
                 location,
                 notes,
@@ -1250,9 +1246,7 @@ function buildMedicationEditFields(data) {
 
 function buildTemperatureEditFields(data) {
     const unit = (data.unit || 'C').toUpperCase();
-    const tempValue = unit === 'F'
-        ? Math.round((data.temperature_celsius * 9 / 5 + 32) * 10) / 10
-        : Math.round(data.temperature_celsius * 10) / 10;
+    const tempValue = Math.round(data.temperature * 10) / 10;
     return `
         <div class="form-group">
             <label for="edit-temp-value">Temperature</label>
@@ -1329,10 +1323,9 @@ function buildEditBody(type) {
             body.dosage_unit = document.getElementById('edit-med-dosage-unit').value;
             break;
         case 'temperature': {
-            let tempValue = parseFloat(document.getElementById('edit-temp-value').value);
+            const tempValue = parseFloat(document.getElementById('edit-temp-value').value);
             const unit = document.getElementById('edit-temp-unit').value;
-            if (unit === 'f') tempValue = (tempValue - 32) * 5 / 9;
-            body.temperature_celsius = Math.round(tempValue * 10) / 10;
+            body.temperature = Math.round(tempValue * 10) / 10;
             body.unit = unit.toUpperCase();
             const loc = document.getElementById('edit-temp-location').value;
             if (loc) body.location = loc;
@@ -1664,19 +1657,16 @@ async function loadDashboard() {
         document.getElementById('last-feeding').textContent =
             data.last_feeding ? `Last: ${timeAgo(data.last_feeding.timestamp)}` : 'No records';
         // Show the most recent reading for the viewed day in the unit it was
-        // recorded in; render no detail line when the day has no reading.
+        // recorded in. When the day has no reading, leave the detail line blank
+        // (not removed) so the card keeps its height — see .card-detail in CSS.
         const tempEl = document.getElementById('last-temp');
         const lastTemp = data.last_temperature;
         if (lastTemp) {
             const unit = (lastTemp.unit || 'C').toUpperCase();
-            const value = unit === 'F'
-                ? Math.round((lastTemp.temperature_celsius * 9 / 5 + 32) * 10) / 10
-                : Math.round(lastTemp.temperature_celsius * 10) / 10;
-            tempEl.textContent = `${value}°${unit}`;
-            tempEl.style.display = '';
+            const value = Math.round(lastTemp.temperature * 10) / 10;
+            tempEl.textContent = `Last temp: ${value}°${unit}`;
         } else {
             tempEl.textContent = '';
-            tempEl.style.display = 'none';
         }
 
         // Refresh the calendar day view

--- a/templates/index.html
+++ b/templates/index.html
@@ -273,7 +273,7 @@
                     <div class="form-group">
                         <label for="temp-value">Temperature</label>
                         <div class="input-group">
-                            <input type="number" name="temperature_celsius" id="temp-value" step="0.1" required>
+                            <input type="number" name="temperature" id="temp-value" step="0.1" required>
                             <select id="temp-unit">
                                 <option value="f">°F</option>
                                 <option value="c">°C</option>

--- a/tests/test_children.py
+++ b/tests/test_children.py
@@ -101,7 +101,7 @@ def test_unassigned_count_spans_every_log_type(client):
         "/api/medications",
         json={"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"},
     )
-    client.post("/api/temperatures", json={"temperature_celsius": 37.0})
+    client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"})
 
     assert client.get("/api/children/unassigned").json()["count"] == 4
 
@@ -110,7 +110,7 @@ def test_bulk_assign_moves_every_unassigned_log(client, child):
     """The one-time migration offer and the later bulk re-assign share this."""
     client.post("/api/diapers", json={"type": "pee"})
     client.post("/api/feedings", json={"feeding_type": "bottle", "amount": 3, "amount_unit": "oz"})
-    client.post("/api/temperatures", json={"temperature_celsius": 37.0})
+    client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"})
 
     resp = client.post(f"/api/children/{child['id']}/assign-unassigned")
     assert resp.status_code == 200
@@ -158,7 +158,7 @@ def test_edit_log_moves_it_between_children(client, two_children):
             "/api/medications",
             {"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"},
         ),
-        ("/api/temperatures", {"temperature_celsius": 37.0}),
+        ("/api/temperatures", {"temperature": 37.0, "unit": "C"}),
     ],
 )
 def test_edit_log_can_set_child_back_to_unassigned(client, child, path, payload):
@@ -263,7 +263,7 @@ def test_export_csv_all_children_includes_child_column(client, two_children):
     maya, theo = two_children
     client.post("/api/diapers", json={"type": "pee", "child_id": maya["id"]})
     client.post("/api/diapers", json={"type": "poop", "child_id": theo["id"]})
-    client.post("/api/temperatures", json={"temperature_celsius": 37.0})
+    client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"})
 
     body = client.get("/api/export?format=csv").text
     assert body.splitlines()[1].endswith("child")
@@ -333,7 +333,7 @@ def test_create_rejects_nonexistent_child_id(client):
             "/api/medications",
             {"medication_name": "Tylenol", "dosage_quantity": 2.5, "dosage_unit": "mL"},
         ),
-        ("/api/temperatures", {"temperature_celsius": 37.2}),
+        ("/api/temperatures", {"temperature": 37.2, "unit": "C"}),
     ):
         resp = client.post(path, json={**payload, "child_id": 999})
         assert resp.status_code == 422, f"{path} accepted a nonexistent child_id"

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -37,8 +37,8 @@ def test_pdf_export_survives_smart_quotes_and_emoji(client):
 
 def test_pdf_export_renders_temperatures_in_recorded_units(client):
     """Mixed-unit temperature readings export without error, each in its unit."""
-    client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "F"})
-    client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "C"})
+    client.post("/api/temperatures", json={"temperature": 98.6, "unit": "F"})
+    client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"})
 
     resp = client.get("/api/export?format=pdf")
     assert resp.status_code == 200
@@ -101,6 +101,20 @@ def test_json_export_stays_utc(client):
 
     data = client.get("/api/export?format=json").json()
     assert data["feedings"][0]["timestamp"] == "2026-07-19T18:30:00Z"
+
+
+def test_json_export_temperature_is_value_as_entered_with_unit(client):
+    """Temperatures export the value as entered plus its unit -- not a Celsius
+    conversion, and not under the old ``temperature_celsius`` key.
+    """
+    client.post("/api/temperatures", json={"temperature": 98.6, "unit": "F"})
+    client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"})
+
+    temps = client.get("/api/export?format=json").json()["temperatures"]
+    by_unit = {t["unit"]: t for t in temps}
+    assert by_unit["F"]["temperature"] == 98.6
+    assert by_unit["C"]["temperature"] == 37.0
+    assert all("temperature_celsius" not in t for t in temps)
 
 
 # --- Low-severity export completeness (second-audit follow-ups) ---

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -147,13 +147,14 @@ def test_create_temperature(client):
     resp = client.post(
         "/api/temperatures",
         json={
-            "temperature_celsius": 37.5,
+            "temperature": 37.5,
+            "unit": "C",
             "location": "rectal",
         },
     )
     assert resp.status_code == 201
     data = resp.json()
-    assert data["temperature_celsius"] == 37.5
+    assert data["temperature"] == 37.5
     assert data["location"] == "rectal"
 
 
@@ -163,80 +164,109 @@ def test_create_temperature_with_timestamp(client):
     resp = client.post(
         "/api/temperatures",
         json={
-            "temperature_celsius": 37.5,
+            "temperature": 37.5,
+            "unit": "C",
             "timestamp": custom_time,
         },
     )
     assert resp.status_code == 201
     data = resp.json()
-    assert data["temperature_celsius"] == 37.5
+    assert data["temperature"] == 37.5
     assert data["timestamp"] == custom_time
 
 
 def test_list_temperatures(client):
-    client.post("/api/temperatures", json={"temperature_celsius": 37.0})
+    client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"})
     resp = client.get("/api/temperatures")
     assert resp.status_code == 200
     assert len(resp.json()) == 1
 
 
 def test_update_temperature(client):
-    create_resp = client.post("/api/temperatures", json={"temperature_celsius": 37.0})
+    create_resp = client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"})
     tid = create_resp.json()["id"]
-    resp = client.put(f"/api/temperatures/{tid}", json={"temperature_celsius": 38.0})
+    resp = client.put(f"/api/temperatures/{tid}", json={"temperature": 38.0})
     assert resp.status_code == 200
-    assert resp.json()["temperature_celsius"] == 38.0
+    assert resp.json()["temperature"] == 38.0
 
 
 def test_delete_temperature(client):
-    create_resp = client.post("/api/temperatures", json={"temperature_celsius": 37.0})
+    create_resp = client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"})
     tid = create_resp.json()["id"]
     assert client.delete(f"/api/temperatures/{tid}").status_code == 204
 
 
+def test_temperature_is_stored_as_entered(client):
+    # A Fahrenheit reading is persisted verbatim, not converted to Celsius.
+    resp = client.post("/api/temperatures", json={"temperature": 99.1, "unit": "F"})
+    assert resp.status_code == 201
+    data = resp.json()
+    assert data["temperature"] == 99.1
+    assert data["unit"] == "F"
+
+
 def test_create_temperature_unit_defaults_to_fahrenheit(client):
-    resp = client.post("/api/temperatures", json={"temperature_celsius": 37.5})
+    resp = client.post("/api/temperatures", json={"temperature": 98.6})
     assert resp.status_code == 201
     assert resp.json()["unit"] == "F"
 
 
 def test_create_temperature_persists_explicit_unit(client):
-    resp = client.post("/api/temperatures", json={"temperature_celsius": 37.5, "unit": "C"})
+    resp = client.post("/api/temperatures", json={"temperature": 37.5, "unit": "C"})
     assert resp.status_code == 201
     assert resp.json()["unit"] == "C"
 
 
-def test_update_temperature_unit(client):
-    tid = client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "C"}).json()[
-        "id"
-    ]
-    resp = client.put(f"/api/temperatures/{tid}", json={"unit": "F"})
+def test_temperature_range_is_unit_aware(client):
+    def post(temp, unit):
+        return client.post("/api/temperatures", json={"temperature": temp, "unit": unit})
+
+    # 98.6 F is a normal reading; 50 F (10 C) is below the plausible range.
+    assert post(98.6, "F").status_code == 201
+    assert post(50, "F").status_code == 422
+    # The same number can be valid in one unit and rejected in the other.
+    assert post(37.0, "C").status_code == 201
+    assert post(37.0, "F").status_code == 422
+
+
+def test_update_temperature_value_and_unit(client):
+    tid = client.post("/api/temperatures", json={"temperature": 98.6, "unit": "F"}).json()["id"]
+    resp = client.put(f"/api/temperatures/{tid}", json={"temperature": 37.0, "unit": "C"})
     assert resp.status_code == 200
-    assert resp.json()["unit"] == "F"
+    body = resp.json()
+    assert body["temperature"] == 37.0
+    assert body["unit"] == "C"
+
+
+def test_update_temperature_unit_only_out_of_range_is_rejected(client):
+    # Relabelling 37.0 C as 37.0 F would mean 2.8 C — out of range, so rejected.
+    tid = client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"}).json()["id"]
+    resp = client.put(f"/api/temperatures/{tid}", json={"unit": "F"})
+    assert resp.status_code == 422
 
 
 def test_dashboard_last_temperature_scoped_to_viewed_day(client):
     # A reading yesterday and one today; each day's dashboard reports its own.
     client.post(
         "/api/temperatures",
-        json={"temperature_celsius": 37.0, "timestamp": "2026-04-05T12:00:00Z"},
+        json={"temperature": 37.0, "unit": "C", "timestamp": "2026-04-05T12:00:00Z"},
     )
     client.post(
         "/api/temperatures",
-        json={"temperature_celsius": 38.0, "timestamp": "2026-04-06T12:00:00Z"},
+        json={"temperature": 38.0, "unit": "C", "timestamp": "2026-04-06T12:00:00Z"},
     )
 
     today = client.get("/api/dashboard?date=2026-04-06").json()
-    assert today["last_temperature"]["temperature_celsius"] == 38.0
+    assert today["last_temperature"]["temperature"] == 38.0
 
     yesterday = client.get("/api/dashboard?date=2026-04-05").json()
-    assert yesterday["last_temperature"]["temperature_celsius"] == 37.0
+    assert yesterday["last_temperature"]["temperature"] == 37.0
 
 
 def test_dashboard_last_temperature_none_when_day_has_no_reading(client):
     client.post(
         "/api/temperatures",
-        json={"temperature_celsius": 37.0, "timestamp": "2026-04-05T12:00:00Z"},
+        json={"temperature": 37.0, "unit": "C", "timestamp": "2026-04-05T12:00:00Z"},
     )
     # A day with no reading returns no last temperature, even though an older
     # reading exists.
@@ -245,8 +275,8 @@ def test_dashboard_last_temperature_none_when_day_has_no_reading(client):
 
 
 def test_activity_feed_temperature_renders_recorded_unit(client):
-    client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "F"})
-    client.post("/api/temperatures", json={"temperature_celsius": 37.0, "unit": "C"})
+    client.post("/api/temperatures", json={"temperature": 98.6, "unit": "F"})
+    client.post("/api/temperatures", json={"temperature": 37.0, "unit": "C"})
     activities = client.get("/api/dashboard").json()["recent_activities"]
     details = {a["detail"] for a in activities if a["type"] == "temperature"}
     assert details == {"98.6°F", "37.0°C"}
@@ -256,7 +286,7 @@ def test_dashboard_last_temperature_reports_recorded_unit(client):
     client.post(
         "/api/temperatures",
         json={
-            "temperature_celsius": 37.0,
+            "temperature": 98.6,
             "unit": "F",
             "timestamp": "2026-04-06T12:00:00Z",
         },
@@ -472,11 +502,12 @@ def test_implausible_temperature_is_rejected(client):
     -500 C was accepted and rendered as -868.0 F in the PDF/CSV export.
     """
     for celsius in (-500, 500, 0, 60):
-        resp = client.post("/api/temperatures", json={"temperature_celsius": celsius})
+        resp = client.post("/api/temperatures", json={"temperature": celsius, "unit": "C"})
         assert resp.status_code == 422, f"{celsius} C was accepted"
 
     # A real fever must still go through.
-    assert client.post("/api/temperatures", json={"temperature_celsius": 39.4}).status_code == 201
+    resp = client.post("/api/temperatures", json={"temperature": 39.4, "unit": "C"})
+    assert resp.status_code == 201
 
 
 def test_saved_medication_survives_a_lost_race(client, monkeypatch):

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -245,16 +245,79 @@ def test_migration_backfills_temperature_unit_as_celsius(tmp_path):
         _run_migrations(bind=engine)
         with engine.connect() as conn:
             cols = {c["name"] for c in inspect(conn).get_columns("temperature_readings")}
-            units = (
-                conn.execute(text("SELECT unit FROM temperature_readings ORDER BY id"))
-                .scalars()
-                .all()
-            )
+            rows = conn.execute(
+                text("SELECT unit, temperature FROM temperature_readings ORDER BY id")
+            ).all()
     finally:
         engine.dispose()
 
     assert "unit" in cols
-    assert units == ["C", "C"]
+    assert "temperature" in cols
+    assert "temperature_celsius" not in cols
+    # Legacy rows have no known unit → treated as Celsius and kept as-is.
+    assert rows == [("C", 37.0), ("C", 38.2)]
+
+
+def test_migration_reconstructs_entered_fahrenheit(tmp_path):
+    """Storing temperatures as entered (#60): ``temperature_celsius`` is renamed
+    to ``temperature``; Fahrenheit rows are reconstructed from their stored
+    Celsius value, Celsius rows are kept as-is.
+    """
+    db_path = tmp_path / "temps_celsius_with_unit.db"
+    raw = sqlite3.connect(db_path)
+    raw.executescript(
+        """
+        CREATE TABLE feedings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME NOT NULL,
+            feeding_type TEXT NOT NULL,
+            duration_minutes INTEGER,
+            amount REAL,
+            amount_unit TEXT,
+            notes TEXT,
+            session_id TEXT,
+            bottle_type TEXT,
+            created_at DATETIME
+        );
+        CREATE TABLE temperature_readings (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            timestamp DATETIME NOT NULL,
+            temperature_celsius REAL NOT NULL,
+            unit TEXT NOT NULL DEFAULT 'C',
+            location TEXT,
+            notes TEXT,
+            created_at DATETIME
+        );
+        INSERT INTO temperature_readings
+            (timestamp, temperature_celsius, unit, location, notes, created_at)
+        VALUES
+            ('2026-04-01 09:00:00', 37.0, 'C', NULL, NULL, '2026-04-01 09:00:00'),
+            ('2026-04-02 09:00:00', 37.0, 'F', NULL, NULL, '2026-04-02 09:00:00');
+        """
+    )
+    raw.commit()
+    raw.close()
+
+    engine = create_engine(
+        f"sqlite:///{db_path}",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    try:
+        _run_migrations(bind=engine)
+        _run_migrations(bind=engine)
+        with engine.connect() as conn:
+            cols = {c["name"] for c in inspect(conn).get_columns("temperature_readings")}
+            rows = conn.execute(
+                text("SELECT unit, temperature FROM temperature_readings ORDER BY id")
+            ).all()
+    finally:
+        engine.dispose()
+
+    assert "temperature" in cols
+    assert "temperature_celsius" not in cols
+    # C row kept as-is; F row reconstructed from stored Celsius: 37.0 C -> 98.6 F.
+    assert rows == [("C", 37.0), ("F", 98.6)]
 
 
 def test_migration_drops_obsolete_dosage_column(legacy_engine):


### PR DESCRIPTION
Closes #60.

Follow-ups to #58/#59 that should have shipped with them — all scoped to the Health card and temperature handling.

## What changed

### 1. Store the temperature as entered
Readings were normalized to Celsius on save and converted back on display, so the persisted value wasn't what the user typed (and was lossy). Now the raw entered value is stored in a `temperature` column, interpreted with the existing `unit`.

- **Rename** `temperature_celsius` → `temperature` across the model, schemas (`TemperatureCreate/Update/Response`), CRUD, frontend, exports, and seed data.
- **No conversion** on create/edit — the value and unit are stored and displayed as-is (`crud.format_temperature` just appends the unit symbol).
- **Unit-aware validation.** The old bounds (`_MIN_TEMP_C`/`_MAX_TEMP_C`, 20–45) assume Celsius, so a raw `98.6°F` would fail. `_temperature_in_range()` converts to Celsius first, wired into the create/update schema validators and the update router (partial updates check against the existing row's unit). **Consequence:** a unit-only edit that pushes the value out of range is now rejected (e.g. relabeling `37.0°C` as `°F` → 422), since no single number is valid in both unit ranges.
- **Migration** adds `temperature`, backfills from `temperature_celsius` (C rows kept; F rows reconstructed from stored Celsius — best-effort, since earlier rounding to Celsius isn't perfectly reversible), then drops the old column. Verified idempotent against a copy of the real DB.
- **Exports:** CSV and PDF render the stored value + unit; JSON follows the schema rename automatically. All three verified to emit `temperature`/`unit` with the as-entered value and no `temperature_celsius`.

### 2. Equalize Health card height on mobile
#58 hid the detail line (`display: none`) on days with no reading, which shrank the Health card in the single-column mobile layout. `.card-detail` now reserves one line (`min-height` matching `line-height`) and the line is kept in flow (blank text) when empty. Verified at 375px: all three cards stay equal height.

### 3. Label the Health card detail line
The temperature now reads `Last temp: 99.1°F`, matching the `Last: …` phrasing on the Diapers and Feedings cards. Blank (no label) when there's no reading for the day.

## Tests
Reworked the temperature suite for the new "value as entered" semantics (the old `#59` tests posted Celsius numbers with `unit: F`, now out of range), and added: unit-aware validation, store-as-entered round-trip, the F-reconstruction migration, and a JSON-export field-name assertion. Full suite: **184 passing**, ruff check + format clean.
